### PR TITLE
기본 이름이 중복되어 생성되는 문제 해결

### DIFF
--- a/src/main/java/com/backend/blooming/authentication/application/AuthenticationService.java
+++ b/src/main/java/com/backend/blooming/authentication/application/AuthenticationService.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @RequiredArgsConstructor
 public class AuthenticationService {
 
+    private static final int NAME_MAX_LENGTH = 50;
     private final OAuthClientComposite oAuthClientComposite;
     private final TokenProvider tokenProvider;
     private final UserRepository userRepository;
@@ -56,10 +57,19 @@ public class AuthenticationService {
         final User savedUser = User.builder()
                                    .oAuthId(userInformationDto.oAuthId())
                                    .oAuthType(oAuthType)
+                                   .name(truncateNameMaxLength(userInformationDto.oAuthId()))
                                    .email(new Email(userInformationDto.email()))
                                    .build();
 
         return userRepository.save(savedUser);
+    }
+
+    private String truncateNameMaxLength(final String oAuthId) {
+        if (oAuthId.length() > NAME_MAX_LENGTH) {
+            return oAuthId.substring(NAME_MAX_LENGTH);
+        }
+
+        return oAuthId;
     }
 
     private TokenDto convertToTokenDto(final User user) {

--- a/src/main/java/com/backend/blooming/user/domain/User.java
+++ b/src/main/java/com/backend/blooming/user/domain/User.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @Table(name = "users")
 public class User extends BaseTimeEntity {
 
-    private static final String DEFAULT_NAME = "";
     private static final String DEFAULT_STATUS_MESSAGE = "";
     private static final ThemeColor DEFAULT_THEME_COLOR = ThemeColor.INDIGO;
 
@@ -70,17 +69,9 @@ public class User extends BaseTimeEntity {
         this.oAuthId = oAuthId;
         this.oAuthType = oAuthType;
         this.email = email;
-        this.name = processName(name);
+        this.name = name;
         this.color = processColor(color);
         this.statusMessage = processStatusMessage(statusMessage);
-    }
-
-    private String processName(final String name) {
-        if (name == null) {
-            return DEFAULT_NAME;
-        }
-
-        return name;
     }
 
     private ThemeColor processColor(final ThemeColor color) {

--- a/src/test/java/com/backend/blooming/user/domain/UserTest.java
+++ b/src/test/java/com/backend/blooming/user/domain/UserTest.java
@@ -15,20 +15,21 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 class UserTest extends UserTestFixture {
 
     @Test
-    void 사용자_생성시_이름_색상_상태메시지를_설정하지_않을시_기본값으로_설정한다() {
+    void 사용자_생성시_색상_상태메시지를_설정하지_않을시_기본값으로_설정한다() {
         // when
         final User actual = User.builder()
-                              .oAuthId("12345")
-                              .oAuthType(OAuthType.KAKAO)
-                              .email(new Email("user@email.com"))
-                              .build();
+                                .oAuthId("12345")
+                                .oAuthType(OAuthType.KAKAO)
+                                .email(new Email("user@email.com"))
+                                .name("test")
+                                .build();
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual.getOAuthId()).isEqualTo("12345");
             softAssertions.assertThat(actual.getOAuthType()).isEqualTo(OAuthType.KAKAO);
             softAssertions.assertThat(actual.getEmail()).isEqualTo("user@email.com");
-            softAssertions.assertThat(actual.getName()).isEqualTo("");
+            softAssertions.assertThat(actual.getName()).isEqualTo("test");
             softAssertions.assertThat(actual.getColor()).isEqualTo(ThemeColor.INDIGO);
             softAssertions.assertThat(actual.getStatusMessage()).isEqualTo("");
         });


### PR DESCRIPTION
- closed #28 

도메인의 객체 생성 시 값이 null이 들어오는 필드에 대해 기본 값으로 설정해 주기로 한 적이 있는데, `name`의 경우 `unique`인 것을 까먹고 수정을 진행했습니다.
그래서 두 명 이상의 사용자 생성 시 문제가 발생하게 되는 경우가 존재해 이에 대해 해결하기 위한 pr입니다.
수정 사항은 간단하기에 확인해 주시면 감사하겠습니다!