### PR TITLE
친구 요청 시 알람 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,7 @@ jacocoTestReport {
 							'**/*Application*',
 							'**/common/**',
 							'**/configuration/**',
+							'**/FCMNotificationService/**'
 					] + Qdomains)
 		}))
 	}
@@ -153,6 +154,7 @@ jacocoTestCoverageVerification {
 					'*.configuration.*',
 					'*.common.*',
 					'*.exception.*',
+					'*.FCMNotificationService.*'
 			] + Qdomains
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+	// fcm
+	implementation 'com.google.firebase:firebase-admin:6.8.1'
+
 	// etc
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
 							'**/*Application*',
 							'**/common/**',
 							'**/configuration/**',
-							'**/FCMNotificationService/**'
+							'**/*FCMNotificationService/**'
 					] + Qdomains)
 		}))
 	}
@@ -154,7 +154,7 @@ jacocoTestCoverageVerification {
 					'*.configuration.*',
 					'*.common.*',
 					'*.exception.*',
-					'*.FCMNotificationService.*'
+					'*.*FCMNotificationService.*'
 			] + Qdomains
 		}
 	}

--- a/src/main/java/com/backend/blooming/configuration/FCMConfiguration.java
+++ b/src/main/java/com/backend/blooming/configuration/FCMConfiguration.java
@@ -32,7 +32,7 @@ public class FCMConfiguration {
     }
 
     private Optional<FirebaseApp> getFirebaseApp() {
-        List<FirebaseApp> firebaseApps = FirebaseApp.getApps();
+        final List<FirebaseApp> firebaseApps = FirebaseApp.getApps();
 
         if (firebaseApps == null || firebaseApps.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/com/backend/blooming/configuration/FCMConfiguration.java
+++ b/src/main/java/com/backend/blooming/configuration/FCMConfiguration.java
@@ -1,0 +1,56 @@
+package com.backend.blooming.configuration;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+@Configuration
+@Profile("prod | dev")
+public class FCMConfiguration {
+
+    @Value("${fcm.key.path}")
+    private String FCM_PRIVATE_KEY_PATH;
+
+    @Value("${fcm.key.scope}")
+    private String fireBaseScope;
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+        final FirebaseApp firebaseApp = getFirebaseApp().orElse(FirebaseApp.initializeApp(createFirebaseOptions()));
+
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+
+    private Optional<FirebaseApp> getFirebaseApp() {
+        List<FirebaseApp> firebaseApps = FirebaseApp.getApps();
+
+        if (firebaseApps == null || firebaseApps.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return firebaseApps.stream()
+                           .filter(firebaseApp -> firebaseApp.getName().equals(FirebaseApp.DEFAULT_APP_NAME))
+                           .findAny();
+    }
+
+    private FirebaseOptions createFirebaseOptions() throws IOException {
+        return new FirebaseOptions.Builder()
+                .setCredentials(createGoogleCredentials())
+                .build();
+    }
+
+    private GoogleCredentials createGoogleCredentials() throws IOException {
+        return GoogleCredentials.fromStream(new ClassPathResource(FCM_PRIVATE_KEY_PATH).getInputStream())
+                                .createScoped(List.of(fireBaseScope));
+    }
+}

--- a/src/main/java/com/backend/blooming/devicetoken/application/service/DeviceTokenService.java
+++ b/src/main/java/com/backend/blooming/devicetoken/application/service/DeviceTokenService.java
@@ -1,10 +1,13 @@
 package com.backend.blooming.devicetoken.application.service;
 
+import com.backend.blooming.devicetoken.application.service.dto.ReadDeviceTokensDto;
 import com.backend.blooming.devicetoken.domain.DeviceToken;
 import com.backend.blooming.devicetoken.infrastructure.repository.DeviceTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -18,5 +21,12 @@ public class DeviceTokenService {
 
         return deviceTokenRepository.save(deviceToken)
                                     .getId();
+    }
+
+    @Transactional(readOnly = true)
+    public ReadDeviceTokensDto readAllByUserId(final Long userId) {
+        final List<DeviceToken> deviceTokens = deviceTokenRepository.readAllByUserIdAndDeletedIsFalse(userId);
+
+        return ReadDeviceTokensDto.from(deviceTokens);
     }
 }

--- a/src/main/java/com/backend/blooming/devicetoken/application/service/DeviceTokenService.java
+++ b/src/main/java/com/backend/blooming/devicetoken/application/service/DeviceTokenService.java
@@ -1,0 +1,22 @@
+package com.backend.blooming.devicetoken.application.service;
+
+import com.backend.blooming.devicetoken.domain.DeviceToken;
+import com.backend.blooming.devicetoken.infrastructure.repository.DeviceTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeviceTokenService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public Long save(final Long userId, final String token) {
+        final DeviceToken deviceToken = new DeviceToken(userId, token);
+
+        return deviceTokenRepository.save(deviceToken)
+                                    .getId();
+    }
+}

--- a/src/main/java/com/backend/blooming/devicetoken/application/service/dto/ReadDeviceTokensDto.java
+++ b/src/main/java/com/backend/blooming/devicetoken/application/service/dto/ReadDeviceTokensDto.java
@@ -1,0 +1,23 @@
+package com.backend.blooming.devicetoken.application.service.dto;
+
+import com.backend.blooming.devicetoken.domain.DeviceToken;
+
+import java.util.List;
+
+public record ReadDeviceTokensDto(List<ReadDeviceTokenDto> deviceTokens) {
+
+    public static ReadDeviceTokensDto from(final List<DeviceToken> deviceTokens) {
+        final List<ReadDeviceTokenDto> deviceTokenDtos = deviceTokens.stream()
+                                                                     .map(ReadDeviceTokenDto::from)
+                                                                     .toList();
+
+        return new ReadDeviceTokensDto(deviceTokenDtos);
+    }
+
+    public record ReadDeviceTokenDto(Long id, Long userId, String deviceToken) {
+
+        public static ReadDeviceTokenDto from(final DeviceToken deviceToken) {
+            return new ReadDeviceTokenDto(deviceToken.getId(), deviceToken.getUserId(), deviceToken.getToken());
+        }
+    }
+}

--- a/src/main/java/com/backend/blooming/devicetoken/domain/DeviceToken.java
+++ b/src/main/java/com/backend/blooming/devicetoken/domain/DeviceToken.java
@@ -30,6 +30,7 @@ public class DeviceToken {
     @Column(nullable = false)
     private String token;
 
+    @Column(name = "is_deleted", nullable = false)
     private boolean deleted = false;
 
     public DeviceToken(final Long userId, final String token) {

--- a/src/main/java/com/backend/blooming/devicetoken/domain/DeviceToken.java
+++ b/src/main/java/com/backend/blooming/devicetoken/domain/DeviceToken.java
@@ -1,0 +1,43 @@
+package com.backend.blooming.devicetoken.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id", callSuper = false)
+@ToString
+@Table
+public class DeviceToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String token;
+
+    private boolean deleted = false;
+
+    public DeviceToken(final Long userId, final String token) {
+        this.userId = userId;
+        this.token = token;
+    }
+
+    public void delete() {
+        this.deleted = true;
+    }
+}

--- a/src/main/java/com/backend/blooming/devicetoken/infrastructure/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/backend/blooming/devicetoken/infrastructure/repository/DeviceTokenRepository.java
@@ -1,0 +1,7 @@
+package com.backend.blooming.devicetoken.infrastructure.repository;
+
+import com.backend.blooming.devicetoken.domain.DeviceToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+}

--- a/src/main/java/com/backend/blooming/devicetoken/infrastructure/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/backend/blooming/devicetoken/infrastructure/repository/DeviceTokenRepository.java
@@ -3,5 +3,9 @@ package com.backend.blooming.devicetoken.infrastructure.repository;
 import com.backend.blooming.devicetoken.domain.DeviceToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+
+    List<DeviceToken> readAllByUserIdAndDeletedIsFalse(final Long userId);
 }

--- a/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
+++ b/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
@@ -27,6 +27,9 @@ public enum ExceptionMessage {
     // 테마 색상
     UNSUPPORTED_THEME_COLOR("지원하지 않는 테마 색상입니다."),
 
+    // 디바이스 토큰
+    NOT_FOUND_DEVICE_TOKEN("디바이스 토큰을 찾을 수 없습니다."),
+
     // 친구
     ALREADY_REQUESTED_FRIEND("이미 친구를 요청한 사용자입니다."),
     NOT_FOUND_FRIEND_REQUEST("해당 친구 요청을 조회할 수 없습니다."),

--- a/src/main/java/com/backend/blooming/friend/application/FriendService.java
+++ b/src/main/java/com/backend/blooming/friend/application/FriendService.java
@@ -7,6 +7,7 @@ import com.backend.blooming.friend.application.exception.FriendAcceptanceForbidd
 import com.backend.blooming.friend.application.exception.NotFoundFriendRequestException;
 import com.backend.blooming.friend.domain.Friend;
 import com.backend.blooming.friend.infrastructure.repository.FriendRepository;
+import com.backend.blooming.notification.application.NotificationService;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
@@ -23,6 +24,7 @@ public class FriendService {
 
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     public Long request(final Long userId, final Long friendId) {
         validateFriendStatus(userId, friendId);
@@ -30,9 +32,11 @@ public class FriendService {
         final User user = findUser(userId);
         final User friendUser = findUser(friendId);
         final Friend friend = new Friend(user, friendUser);
+        friendRepository.save(friend);
 
-        return friendRepository.save(friend)
-                               .getId();
+        notificationService.sendRequestFriendNotification(friend);
+
+        return friend.getId();
     }
 
     private void validateFriendStatus(final Long userId, final Long friendId) {

--- a/src/main/java/com/backend/blooming/notification/application/FCMNotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/FCMNotificationService.java
@@ -1,0 +1,80 @@
+package com.backend.blooming.notification.application;
+
+import com.backend.blooming.devicetoken.domain.DeviceToken;
+import com.backend.blooming.devicetoken.infrastructure.repository.DeviceTokenRepository;
+import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.user.domain.User;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.SendResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.backend.blooming.notification.application.util.NotificationKey.BODY;
+import static com.backend.blooming.notification.application.util.NotificationKey.REQUEST_ID;
+import static com.backend.blooming.notification.application.util.NotificationKey.TITLE;
+import static com.backend.blooming.notification.application.util.NotificationKey.TYPE;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Profile("prod | dev")
+public class FCMNotificationService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public void sendNotification(final Notification notification) {
+        List<String> deviceTokens = getDeviceTokens(notification.getReceiver());
+        List<Message> messages = createMessages(notification, deviceTokens);
+
+        try {
+            final BatchResponse batchResponse = firebaseMessaging.sendAll(messages);
+            checkAllSuccess(batchResponse);
+        } catch (FirebaseMessagingException exception) {
+            log.error("보낼 알림이 없거나, 알림 보내기에 실패했습니다. : ", exception);
+        }
+    }
+
+    private List<String> getDeviceTokens(final User receiver) {
+        return deviceTokenRepository.readAllByUserIdAndDeletedIsFalse(receiver.getId())
+                                    .stream()
+                                    .map(DeviceToken::getToken)
+                                    .toList();
+    }
+
+    private List<Message> createMessages(final Notification notification, final List<String> deviceTokens) {
+        return deviceTokens.stream()
+                           .map(deviceToken -> createMessage(notification, deviceToken))
+                           .toList();
+    }
+
+    private Message createMessage(final Notification notification, final String deviceToken) {
+        return Message.builder()
+                      .setToken(deviceToken)
+                      .putData(TITLE.getValue(), notification.getTitle())
+                      .putData(BODY.getValue(), notification.getContent())
+                      .putData(TYPE.getValue(), notification.getType().name())
+                      .putData(REQUEST_ID.getValue(), notification.getRequestId().toString())
+                      .build();
+    }
+
+    private void checkAllSuccess(final BatchResponse batchResponse) {
+        if (batchResponse.getFailureCount() > 0) {
+            final List<SendResponse> failResponses = batchResponse.getResponses()
+                                                                  .stream()
+                                                                  .filter(sendResponse -> !sendResponse.isSuccessful())
+                                                                  .toList();
+
+            log.warn("알림 보내기에 실패 요청이 있습니다. 실패 개수: {}, {}", batchResponse.getFailureCount(), failResponses);
+        }
+    }
+}

--- a/src/main/java/com/backend/blooming/notification/application/FCMNotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/FCMNotificationService.java
@@ -1,80 +1,8 @@
 package com.backend.blooming.notification.application;
 
-import com.backend.blooming.devicetoken.domain.DeviceToken;
-import com.backend.blooming.devicetoken.infrastructure.repository.DeviceTokenRepository;
 import com.backend.blooming.notification.domain.Notification;
-import com.backend.blooming.user.domain.User;
-import com.google.firebase.messaging.BatchResponse;
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.SendResponse;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+public interface FCMNotificationService {
 
-import static com.backend.blooming.notification.application.util.NotificationKey.BODY;
-import static com.backend.blooming.notification.application.util.NotificationKey.REQUEST_ID;
-import static com.backend.blooming.notification.application.util.NotificationKey.TITLE;
-import static com.backend.blooming.notification.application.util.NotificationKey.TYPE;
-
-@Slf4j
-@Service
-@Transactional
-@RequiredArgsConstructor
-@Profile("prod | dev")
-public class FCMNotificationService {
-
-    private final FirebaseMessaging firebaseMessaging;
-    private final DeviceTokenRepository deviceTokenRepository;
-
-    public void sendNotification(final Notification notification) {
-        List<String> deviceTokens = getDeviceTokens(notification.getReceiver());
-        List<Message> messages = createMessages(notification, deviceTokens);
-
-        try {
-            final BatchResponse batchResponse = firebaseMessaging.sendAll(messages);
-            checkAllSuccess(batchResponse);
-        } catch (FirebaseMessagingException exception) {
-            log.error("보낼 알림이 없거나, 알림 보내기에 실패했습니다. : ", exception);
-        }
-    }
-
-    private List<String> getDeviceTokens(final User receiver) {
-        return deviceTokenRepository.readAllByUserIdAndDeletedIsFalse(receiver.getId())
-                                    .stream()
-                                    .map(DeviceToken::getToken)
-                                    .toList();
-    }
-
-    private List<Message> createMessages(final Notification notification, final List<String> deviceTokens) {
-        return deviceTokens.stream()
-                           .map(deviceToken -> createMessage(notification, deviceToken))
-                           .toList();
-    }
-
-    private Message createMessage(final Notification notification, final String deviceToken) {
-        return Message.builder()
-                      .setToken(deviceToken)
-                      .putData(TITLE.getValue(), notification.getTitle())
-                      .putData(BODY.getValue(), notification.getContent())
-                      .putData(TYPE.getValue(), notification.getType().name())
-                      .putData(REQUEST_ID.getValue(), notification.getRequestId().toString())
-                      .build();
-    }
-
-    private void checkAllSuccess(final BatchResponse batchResponse) {
-        if (batchResponse.getFailureCount() > 0) {
-            final List<SendResponse> failResponses = batchResponse.getResponses()
-                                                                  .stream()
-                                                                  .filter(sendResponse -> !sendResponse.isSuccessful())
-                                                                  .toList();
-
-            log.warn("알림 보내기에 실패 요청이 있습니다. 실패 개수: {}, {}", batchResponse.getFailureCount(), failResponses);
-        }
-    }
+    void sendNotification(final Notification notification);
 }

--- a/src/main/java/com/backend/blooming/notification/application/LocalFCMNotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/LocalFCMNotificationService.java
@@ -1,0 +1,13 @@
+package com.backend.blooming.notification.application;
+
+import com.backend.blooming.notification.domain.Notification;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("local | test")
+public class LocalFCMNotificationService implements FCMNotificationService {
+
+    @Override
+    public void sendNotification(final Notification notification) {}
+}

--- a/src/main/java/com/backend/blooming/notification/application/NotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/NotificationService.java
@@ -20,6 +20,7 @@ import static com.backend.blooming.notification.domain.NotificationType.REQUEST_
 @RequiredArgsConstructor
 public class NotificationService {
 
+    private final FCMNotificationService fcmNotificationService;
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
 
@@ -36,6 +37,7 @@ public class NotificationService {
         final Notification savedNotification = notificationRepository.save(notification);
 
         friend.getRequestedUser().updateNewAlarm(true);
+        fcmNotificationService.sendNotification(notification);
 
         return savedNotification.getId();
     }

--- a/src/main/java/com/backend/blooming/notification/application/NotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/NotificationService.java
@@ -1,11 +1,16 @@
 package com.backend.blooming.notification.application;
 
 import com.backend.blooming.friend.domain.Friend;
+import com.backend.blooming.notification.application.dto.ReadNotificationsDto;
 import com.backend.blooming.notification.domain.Notification;
 import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
+import com.backend.blooming.user.application.exception.NotFoundUserException;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
 
@@ -15,6 +20,7 @@ import static com.backend.blooming.notification.domain.NotificationType.REQUEST_
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
 
     public Long sendRequestFriendNotification(final Friend friend) {
         final Notification notification = Notification.builder()
@@ -29,5 +35,15 @@ public class NotificationService {
 
         return notificationRepository.save(notification)
                                      .getId();
+    }
+
+    @Transactional(readOnly = true)
+    public ReadNotificationsDto readAllByUserId(final Long userId) {
+        if (!userRepository.existsByIdAndDeletedIsFalse(userId)) {
+            throw new NotFoundUserException();
+        }
+        final List<Notification> notifications = notificationRepository.readAllByReceiverId(userId);
+
+        return ReadNotificationsDto.from(notifications);
     }
 }

--- a/src/main/java/com/backend/blooming/notification/application/NotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/NotificationService.java
@@ -30,7 +30,7 @@ public class NotificationService {
                                                               friend.getRequestUser().getName()
                                                       ))
                                                       .type(REQUEST_FRIEND)
-                                                      .requestId(friend.getRequestedUser().getId())
+                                                      .requestId(friend.getRequestUser().getId())
                                                       .build();
 
         return notificationRepository.save(notification)
@@ -42,7 +42,7 @@ public class NotificationService {
         if (!userRepository.existsByIdAndDeletedIsFalse(userId)) {
             throw new NotFoundUserException();
         }
-        final List<Notification> notifications = notificationRepository.readAllByReceiverId(userId);
+        final List<Notification> notifications = notificationRepository.findAllByReceiverId(userId);
 
         return ReadNotificationsDto.from(notifications);
     }

--- a/src/main/java/com/backend/blooming/notification/application/NotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/NotificationService.java
@@ -1,0 +1,33 @@
+package com.backend.blooming.notification.application;
+
+import com.backend.blooming.friend.domain.Friend;
+import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public Long sendRequestFriendNotification(final Friend friend) {
+        final Notification notification = Notification.builder()
+                                                      .receiver(friend.getRequestedUser())
+                                                      .title(REQUEST_FRIEND.getTitle())
+                                                      .content(REQUEST_FRIEND.getContentByFormat(
+                                                              friend.getRequestUser().getName()
+                                                      ))
+                                                      .type(REQUEST_FRIEND)
+                                                      .requestId(friend.getRequestedUser().getId())
+                                                      .build();
+
+        return notificationRepository.save(notification)
+                                     .getId();
+    }
+}

--- a/src/main/java/com/backend/blooming/notification/application/ProdFCMNotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/ProdFCMNotificationService.java
@@ -33,8 +33,8 @@ public class ProdFCMNotificationService implements FCMNotificationService {
     private final DeviceTokenRepository deviceTokenRepository;
 
     public void sendNotification(final Notification notification) {
-        List<String> deviceTokens = getDeviceTokens(notification.getReceiver());
-        List<Message> messages = createMessages(notification, deviceTokens);
+        final List<String> deviceTokens = getDeviceTokens(notification.getReceiver());
+        final List<Message> messages = createMessages(notification, deviceTokens);
 
         try {
             final BatchResponse batchResponse = firebaseMessaging.sendAll(messages);

--- a/src/main/java/com/backend/blooming/notification/application/ProdFCMNotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/ProdFCMNotificationService.java
@@ -1,0 +1,80 @@
+package com.backend.blooming.notification.application;
+
+import com.backend.blooming.devicetoken.domain.DeviceToken;
+import com.backend.blooming.devicetoken.infrastructure.repository.DeviceTokenRepository;
+import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.user.domain.User;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.SendResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.backend.blooming.notification.application.util.NotificationKey.BODY;
+import static com.backend.blooming.notification.application.util.NotificationKey.REQUEST_ID;
+import static com.backend.blooming.notification.application.util.NotificationKey.TITLE;
+import static com.backend.blooming.notification.application.util.NotificationKey.TYPE;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Profile("prod | dev")
+public class ProdFCMNotificationService implements FCMNotificationService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public void sendNotification(final Notification notification) {
+        List<String> deviceTokens = getDeviceTokens(notification.getReceiver());
+        List<Message> messages = createMessages(notification, deviceTokens);
+
+        try {
+            final BatchResponse batchResponse = firebaseMessaging.sendAll(messages);
+            checkAllSuccess(batchResponse);
+        } catch (FirebaseMessagingException exception) {
+            log.error("보낼 알림이 없거나, 알림 보내기에 실패했습니다. : ", exception);
+        }
+    }
+
+    private List<String> getDeviceTokens(final User receiver) {
+        return deviceTokenRepository.readAllByUserIdAndDeletedIsFalse(receiver.getId())
+                                    .stream()
+                                    .map(DeviceToken::getToken)
+                                    .toList();
+    }
+
+    private List<Message> createMessages(final Notification notification, final List<String> deviceTokens) {
+        return deviceTokens.stream()
+                           .map(deviceToken -> createMessage(notification, deviceToken))
+                           .toList();
+    }
+
+    private Message createMessage(final Notification notification, final String deviceToken) {
+        return Message.builder()
+                      .setToken(deviceToken)
+                      .putData(TITLE.getValue(), notification.getTitle())
+                      .putData(BODY.getValue(), notification.getContent())
+                      .putData(TYPE.getValue(), notification.getType().name())
+                      .putData(REQUEST_ID.getValue(), notification.getRequestId().toString())
+                      .build();
+    }
+
+    private void checkAllSuccess(final BatchResponse batchResponse) {
+        if (batchResponse.getFailureCount() > 0) {
+            final List<SendResponse> failResponses = batchResponse.getResponses()
+                                                                  .stream()
+                                                                  .filter(sendResponse -> !sendResponse.isSuccessful())
+                                                                  .toList();
+
+            log.warn("알림 보내기에 실패 요청이 있습니다. 실패 개수: {}, {}", batchResponse.getFailureCount(), failResponses);
+        }
+    }
+}

--- a/src/main/java/com/backend/blooming/notification/application/dto/ReadNotificationsDto.java
+++ b/src/main/java/com/backend/blooming/notification/application/dto/ReadNotificationsDto.java
@@ -1,0 +1,37 @@
+package com.backend.blooming.notification.application.dto;
+
+import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.notification.domain.NotificationType;
+
+import java.util.List;
+
+public record ReadNotificationsDto(List<ReadNotificationDto> notifications) {
+
+
+    public static ReadNotificationsDto from(final List<Notification> notifications) {
+        final List<ReadNotificationDto> notificationDtos = notifications.stream()
+                                                                          .map(ReadNotificationDto::from)
+                                                                          .toList();
+
+        return new ReadNotificationsDto(notificationDtos);
+    }
+
+    public record ReadNotificationDto(
+            Long id,
+            String title,
+            String content,
+            NotificationType type,
+            Long requestId
+    ) {
+
+        public static ReadNotificationDto from(final Notification notification) {
+            return new ReadNotificationDto(
+                    notification.getId(),
+                    notification.getTitle(),
+                    notification.getContent(),
+                    notification.getType(),
+                    notification.getRequestId()
+            );
+        }
+    }
+}

--- a/src/main/java/com/backend/blooming/notification/application/util/NotificationKey.java
+++ b/src/main/java/com/backend/blooming/notification/application/util/NotificationKey.java
@@ -1,0 +1,17 @@
+package com.backend.blooming.notification.application.util;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum NotificationKey {
+
+    TITLE("title"),
+    BODY("body"),
+    TYPE("type"),
+    REQUEST_ID("requestId");
+
+    private final String value;
+}

--- a/src/main/java/com/backend/blooming/notification/domain/Notification.java
+++ b/src/main/java/com/backend/blooming/notification/domain/Notification.java
@@ -1,0 +1,67 @@
+package com.backend.blooming.notification.domain;
+
+import com.backend.blooming.common.entity.BaseTimeEntity;
+import com.backend.blooming.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id", callSuper = false)
+@ToString
+@Table
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false, foreignKey = @ForeignKey(name = "fk_notification_receiver"))
+    private User receiver;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private NotificationType type;
+
+    // TODO: 1/23/24 [고민] NOT NULL 처리 해주는 것이 좋을까요?
+    private Long requestId;
+
+    @Builder
+    private Notification(
+            final User receiver,
+            final String title,
+            final String content,
+            final NotificationType type,
+            final Long requestId
+    ) {
+        this.receiver = receiver;
+        this.title = title;
+        this.content = content;
+        this.type = type;
+        this.requestId = requestId;
+    }
+}

--- a/src/main/java/com/backend/blooming/notification/domain/Notification.java
+++ b/src/main/java/com/backend/blooming/notification/domain/Notification.java
@@ -47,7 +47,6 @@ public class Notification extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private NotificationType type;
 
-    // TODO: 1/23/24 [고민] NOT NULL 처리 해주는 것이 좋을까요?
     private Long requestId;
 
     @Builder

--- a/src/main/java/com/backend/blooming/notification/domain/Notification.java
+++ b/src/main/java/com/backend/blooming/notification/domain/Notification.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EqualsAndHashCode(of = "id", callSuper = false)
-@ToString
+@ToString(exclude = "receiver")
 @Table
 public class Notification extends BaseTimeEntity {
 

--- a/src/main/java/com/backend/blooming/notification/domain/NotificationType.java
+++ b/src/main/java/com/backend/blooming/notification/domain/NotificationType.java
@@ -1,6 +1,19 @@
 package com.backend.blooming.notification.domain;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 public enum NotificationType {
 
-    REQUEST_FRIEND
+    REQUEST_FRIEND("친구 신청", "%s님이 회원님에게 친구 신청을 요청했습니다.");
+
+    private final String title;
+    private final String content;
+
+    public String getContentByFormat(final String value) {
+        return String.format(content, value);
+    }
 }

--- a/src/main/java/com/backend/blooming/notification/domain/NotificationType.java
+++ b/src/main/java/com/backend/blooming/notification/domain/NotificationType.java
@@ -1,0 +1,6 @@
+package com.backend.blooming.notification.domain;
+
+public enum NotificationType {
+
+    REQUEST_FRIEND
+}

--- a/src/main/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepository.java
+++ b/src/main/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepository.java
@@ -3,5 +3,9 @@ package com.backend.blooming.notification.infrastructure.repository;
 import com.backend.blooming.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> readAllByReceiverId(final Long userId);
 }

--- a/src/main/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepository.java
+++ b/src/main/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    List<Notification> readAllByReceiverId(final Long userId);
+    List<Notification> findAllByReceiverId(final Long userId);
 }

--- a/src/main/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepository.java
+++ b/src/main/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.backend.blooming.notification.infrastructure.repository;
+
+import com.backend.blooming.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/backend/blooming/notification/presentation/NotificationController.java
+++ b/src/main/java/com/backend/blooming/notification/presentation/NotificationController.java
@@ -1,0 +1,26 @@
+package com.backend.blooming.notification.presentation;
+
+import com.backend.blooming.authentication.presentation.anotaion.Authenticated;
+import com.backend.blooming.authentication.presentation.argumentresolver.AuthenticatedUser;
+import com.backend.blooming.notification.application.NotificationService;
+import com.backend.blooming.notification.application.dto.ReadNotificationsDto;
+import com.backend.blooming.notification.presentation.dto.ReadNotificationsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping(headers = "X-API-VERSION=1")
+    public ReadNotificationsResponse readAllByUserId(@Authenticated final AuthenticatedUser authenticatedUser) {
+        final ReadNotificationsDto notificationsDto = notificationService.readAllByUserId(authenticatedUser.userId());
+
+        return ReadNotificationsResponse.from(notificationsDto);
+    }
+}

--- a/src/main/java/com/backend/blooming/notification/presentation/dto/ReadNotificationsResponse.java
+++ b/src/main/java/com/backend/blooming/notification/presentation/dto/ReadNotificationsResponse.java
@@ -1,0 +1,32 @@
+package com.backend.blooming.notification.presentation.dto;
+
+import com.backend.blooming.notification.application.dto.ReadNotificationsDto;
+
+import java.util.List;
+
+public record ReadNotificationsResponse(List<ReadNotificationResponse> notifications) {
+
+    public static ReadNotificationsResponse from(final ReadNotificationsDto notificationsDto) {
+        final List<ReadNotificationResponse> notificationResponses = notificationsDto.notifications()
+                                                                                     .stream()
+                                                                                     .map(ReadNotificationResponse::from)
+                                                                                     .toList();
+
+        return new ReadNotificationsResponse(notificationResponses);
+    }
+
+    public record ReadNotificationResponse(Long id, String title, String content, String type, Long requestId) {
+
+        public static ReadNotificationResponse from(
+                final ReadNotificationsDto.ReadNotificationDto readNotificationDto
+        ) {
+            return new ReadNotificationResponse(
+                    readNotificationDto.id(),
+                    readNotificationDto.title(),
+                    readNotificationDto.content(),
+                    readNotificationDto.type().name(),
+                    readNotificationDto.requestId()
+            );
+        }
+    }
+}

--- a/src/main/java/com/backend/blooming/user/domain/User.java
+++ b/src/main/java/com/backend/blooming/user/domain/User.java
@@ -54,7 +54,10 @@ public class User extends BaseTimeEntity {
     @Column(columnDefinition = "text", nullable = false)
     private String statusMessage;
 
-    @Column(name = "is_deleted")
+    @Column(name = "is_new_alarm", nullable = false)
+    private boolean newAlarm = false;
+
+    @Column(name = "is_deleted", nullable = false)
     private boolean deleted = false;
 
     @Builder
@@ -104,6 +107,10 @@ public class User extends BaseTimeEntity {
 
     public void updateStatusMessage(final String statusMessage) {
         this.statusMessage = statusMessage;
+    }
+
+    public void updateNewAlarm(final boolean newAlarm) {
+        this.newAlarm = newAlarm;
     }
 
     public String getEmail() {

--- a/src/main/java/com/backend/blooming/user/presentation/dto/response/ReadUsersWithFriendsStatusResponse.java
+++ b/src/main/java/com/backend/blooming/user/presentation/dto/response/ReadUsersWithFriendsStatusResponse.java
@@ -4,7 +4,7 @@ import com.backend.blooming.user.application.dto.ReadUsersWithFriendsStatusDto;
 
 import java.util.List;
 
-import static com.backend.blooming.user.application.dto.ReadUsersWithFriendsStatusDto.*;
+import static com.backend.blooming.user.application.dto.ReadUsersWithFriendsStatusDto.ReadUserWithFriendsStatusDto;
 
 public record ReadUsersWithFriendsStatusResponse(List<ReadUserWithFriendsStatusResponse> users) {
 

--- a/src/main/resources/static/docs/authentication.html
+++ b/src/main/resources/static/docs/authentication.html
@@ -663,7 +663,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-06 23:40:51 +0900
+Last updated 2024-01-11 13:10:33 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/docs.html
+++ b/src/main/resources/static/docs/docs.html
@@ -1877,8 +1877,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-01-21",
-  "endDate" : "2024-03-01",
+  "startDate" : "2024-01-26",
+  "endDate" : "2024-03-06",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -2050,8 +2050,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-01-21",
-  "endDate" : "2024-01-31",
+  "startDate" : "2024-01-26",
+  "endDate" : "2024-02-05",
   "days" : 11,
   "managerId" : 1,
   "goalTeamWithUserInfo" : [ {
@@ -2077,8 +2077,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-01-21",
-  "endDate" : "2024-01-31",
+  "startDate" : "2024-01-26",
+  "endDate" : "2024-02-05",
   "days" : 11,
   "managerId" : 1,
   "goalTeamWithUserInfo" : [ {
@@ -2225,8 +2225,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-01-21",
-    "endDate" : "2024-01-31",
+    "startDate" : "2024-01-26",
+    "endDate" : "2024-02-05",
     "days" : 11,
     "goalTeamWithUserInfos" : [ {
       "id" : 1,
@@ -2240,8 +2240,8 @@ Content-Type: application/json
   }, {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-01-21",
-    "endDate" : "2024-02-10",
+    "startDate" : "2024-01-26",
+    "endDate" : "2024-02-15",
     "days" : 21,
     "goalTeamWithUserInfos" : [ {
       "id" : 1,
@@ -2265,8 +2265,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-01-21",
-    "endDate" : "2024-01-31",
+    "startDate" : "2024-01-26",
+    "endDate" : "2024-02-05",
     "days" : 11,
     "goalTeamWithUserInfos" : [ {
       "id" : 1,
@@ -2280,8 +2280,8 @@ Content-Type: application/json
   }, {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-01-21",
-    "endDate" : "2024-02-10",
+    "startDate" : "2024-01-26",
+    "endDate" : "2024-02-15",
     "days" : 21,
     "goalTeamWithUserInfos" : [ {
       "id" : 1,
@@ -2364,7 +2364,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-21 04:27:18 +0900
+Last updated 2024-01-23 17:06:35 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/friend.html
+++ b/src/main/resources/static/docs/friend.html
@@ -1075,7 +1075,7 @@ Authorization: Bearer access_token</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-06 23:40:51 +0900
+Last updated 2024-01-11 13:10:33 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/goal.html
+++ b/src/main/resources/static/docs/goal.html
@@ -456,8 +456,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-01-21",
-  "endDate" : "2024-03-01",
+  "startDate" : "2024-01-26",
+  "endDate" : "2024-03-06",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -629,8 +629,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-01-21",
-  "endDate" : "2024-01-31",
+  "startDate" : "2024-01-26",
+  "endDate" : "2024-02-05",
   "days" : 11,
   "managerId" : 1,
   "goalTeamWithUserInfo" : [ {
@@ -656,8 +656,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-01-21",
-  "endDate" : "2024-01-31",
+  "startDate" : "2024-01-26",
+  "endDate" : "2024-02-05",
   "days" : 11,
   "managerId" : 1,
   "goalTeamWithUserInfo" : [ {
@@ -804,8 +804,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-01-21",
-    "endDate" : "2024-01-31",
+    "startDate" : "2024-01-26",
+    "endDate" : "2024-02-05",
     "days" : 11,
     "goalTeamWithUserInfos" : [ {
       "id" : 1,
@@ -819,8 +819,8 @@ Content-Type: application/json
   }, {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-01-21",
-    "endDate" : "2024-02-10",
+    "startDate" : "2024-01-26",
+    "endDate" : "2024-02-15",
     "days" : 21,
     "goalTeamWithUserInfos" : [ {
       "id" : 1,
@@ -844,8 +844,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-01-21",
-    "endDate" : "2024-01-31",
+    "startDate" : "2024-01-26",
+    "endDate" : "2024-02-05",
     "days" : 11,
     "goalTeamWithUserInfos" : [ {
       "id" : 1,
@@ -859,8 +859,8 @@ Content-Type: application/json
   }, {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-01-21",
-    "endDate" : "2024-02-10",
+    "startDate" : "2024-01-26",
+    "endDate" : "2024-02-15",
     "days" : 21,
     "goalTeamWithUserInfos" : [ {
       "id" : 1,
@@ -941,7 +941,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-21 04:27:18 +0900
+Last updated 2024-01-23 17:06:35 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/themecolor.html
+++ b/src/main/resources/static/docs/themecolor.html
@@ -524,7 +524,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-06 23:40:51 +0900
+Last updated 2024-01-11 13:10:33 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/user.html
+++ b/src/main/resources/static/docs/user.html
@@ -823,7 +823,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-06 23:40:51 +0900
+Last updated 2024-01-11 13:10:33 +0900
 </div>
 </div>
 </body>

--- a/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTest.java
@@ -1,0 +1,27 @@
+package com.backend.blooming.devicetoken.application.service;
+
+import com.backend.blooming.configuration.IsolateDatabase;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IsolateDatabase
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class DeviceTokenServiceTest extends DeviceTokenServiceTestFixture {
+
+    @Autowired
+    private DeviceTokenService deviceTokenService;
+
+    @Test
+    void 디바이스_토큰을_저장한다() {
+        // when
+        final Long actual = deviceTokenService.save(사용자_아이디, 디바이스_토큰);
+
+        // then
+        assertThat(actual).isPositive();
+    }
+}

--- a/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTest.java
@@ -1,6 +1,8 @@
 package com.backend.blooming.devicetoken.application.service;
 
 import com.backend.blooming.configuration.IsolateDatabase;
+import com.backend.blooming.devicetoken.application.service.dto.ReadDeviceTokensDto;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -23,5 +25,20 @@ class DeviceTokenServiceTest extends DeviceTokenServiceTestFixture {
 
         // then
         assertThat(actual).isPositive();
+    }
+
+    @Test
+    void 사용자의_디바이스_토큰_목록_조회() {
+        // when
+        final ReadDeviceTokensDto actual = deviceTokenService.readAllByUserId(사용자_아이디);
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.deviceTokens()).hasSize(2);
+            softAssertions.assertThat(actual.deviceTokens().get(0).id()).isEqualTo(디바이스_토큰1.getId());
+            softAssertions.assertThat(actual.deviceTokens().get(0).deviceToken()).isEqualTo(디바이스_토큰1.getToken());
+            softAssertions.assertThat(actual.deviceTokens().get(1).id()).isEqualTo(디바이스_토큰2.getId());
+            softAssertions.assertThat(actual.deviceTokens().get(1).deviceToken()).isEqualTo(디바이스_토큰2.getToken());
+        });
     }
 }

--- a/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTestFixture.java
@@ -1,8 +1,28 @@
 package com.backend.blooming.devicetoken.application.service;
 
+import com.backend.blooming.devicetoken.domain.DeviceToken;
+import com.backend.blooming.devicetoken.infrastructure.repository.DeviceTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
 @SuppressWarnings("NonAsciiCharacters")
 public class DeviceTokenServiceTestFixture {
 
+    @Autowired
+    private DeviceTokenRepository deviceTokenRepository;
+
     protected Long 사용자_아이디 = 1L;
     protected String 디바이스_토큰 = "token";
+    protected DeviceToken 디바이스_토큰1;
+    protected DeviceToken 디바이스_토큰2;
+
+    @BeforeEach
+    void setUpFixture() {
+        디바이스_토큰1 = new DeviceToken(사용자_아이디, "toekn1");
+        디바이스_토큰2 = new DeviceToken(사용자_아이디, "toekn2");
+
+        deviceTokenRepository.saveAll(List.of(디바이스_토큰1, 디바이스_토큰2));
+    }
 }

--- a/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTestFixture.java
@@ -1,0 +1,8 @@
+package com.backend.blooming.devicetoken.application.service;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class DeviceTokenServiceTestFixture {
+
+    protected Long 사용자_아이디 = 1L;
+    protected String 디바이스_토큰 = "token";
+}

--- a/src/test/java/com/backend/blooming/devicetoken/domain/DeviceTokenTest.java
+++ b/src/test/java/com/backend/blooming/devicetoken/domain/DeviceTokenTest.java
@@ -1,0 +1,24 @@
+package com.backend.blooming.devicetoken.domain;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class DeviceTokenTest {
+
+    @Test
+    void 디바이스_토큰을_삭제한다() {
+        // given
+        final DeviceToken deviceToken = new DeviceToken(1L, "token");
+
+        // when
+        deviceToken.delete();
+
+        // then
+        assertThat(deviceToken.isDeleted()).isTrue();
+    }
+}

--- a/src/test/java/com/backend/blooming/devicetoken/infrastructure/repository/DeviceTokenRepositoryTest.java
+++ b/src/test/java/com/backend/blooming/devicetoken/infrastructure/repository/DeviceTokenRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.backend.blooming.devicetoken.infrastructure.repository;
+
+import com.backend.blooming.configuration.JpaConfiguration;
+import com.backend.blooming.devicetoken.domain.DeviceToken;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+@DataJpaTest
+@Import(JpaConfiguration.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class DeviceTokenRepositoryTest extends DeviceTokenRepositoryTestFixture {
+
+    @Autowired
+    private DeviceTokenRepository deviceTokenRepository;
+
+    @Test
+    void 사용자의_삭제되지_않은_모든_디바이스_토큰_목록을_조회한다() {
+        // when
+        final List<DeviceToken> actual = deviceTokenRepository.readAllByUserIdAndDeletedIsFalse(사용자_아이디);
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(2);
+            softAssertions.assertThat(actual.get(0).getId()).isEqualTo(디바이스_토큰1.getId());
+            softAssertions.assertThat(actual.get(0).getToken()).isEqualTo(디바이스_토큰1.getToken());
+            softAssertions.assertThat(actual.get(1).getId()).isEqualTo(디바이스_토큰2.getId());
+            softAssertions.assertThat(actual.get(1).getToken()).isEqualTo(디바이스_토큰2.getToken());
+            softAssertions.assertThat(actual).doesNotContain(삭제된_디바이스_토큰);
+        });
+    }
+}

--- a/src/test/java/com/backend/blooming/devicetoken/infrastructure/repository/DeviceTokenRepositoryTestFixture.java
+++ b/src/test/java/com/backend/blooming/devicetoken/infrastructure/repository/DeviceTokenRepositoryTestFixture.java
@@ -1,0 +1,29 @@
+package com.backend.blooming.devicetoken.infrastructure.repository;
+
+import com.backend.blooming.devicetoken.domain.DeviceToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class DeviceTokenRepositoryTestFixture {
+
+    @Autowired
+    private DeviceTokenRepository deviceTokenRepository;
+
+    protected Long 사용자_아이디 = 1L;
+    protected DeviceToken 디바이스_토큰1;
+    protected DeviceToken 디바이스_토큰2;
+    protected DeviceToken 삭제된_디바이스_토큰;
+
+    @BeforeEach
+    void setUpFixture() {
+        디바이스_토큰1 = new DeviceToken(사용자_아이디, "token1");
+        디바이스_토큰2 = new DeviceToken(사용자_아이디, "token2");
+        삭제된_디바이스_토큰 = new DeviceToken(사용자_아이디, "token3");
+        삭제된_디바이스_토큰.delete();
+
+        deviceTokenRepository.saveAll(List.of(디바이스_토큰1, 디바이스_토큰2, 삭제된_디바이스_토큰));
+    }
+}

--- a/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
+++ b/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
@@ -8,12 +8,16 @@ import com.backend.blooming.friend.application.exception.FriendAcceptanceForbidd
 import com.backend.blooming.friend.application.exception.NotFoundFriendRequestException;
 import com.backend.blooming.friend.domain.Friend;
 import com.backend.blooming.friend.infrastructure.repository.FriendRepository;
+import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +35,9 @@ class FriendServiceTest extends FriendServiceTestFixture {
     @Autowired
     private FriendRepository friendRepository;
 
+    @Autowired
+    private NotificationRepository notificationRepository;
+
     @Test
     void 친구를_요청한다() {
         // when
@@ -38,6 +45,22 @@ class FriendServiceTest extends FriendServiceTestFixture {
 
         // then
         assertThat(actual).isPositive();
+    }
+
+    @Test
+    void 친구_요청시_요청_상대에게_알림이_저장된다() {
+
+        // when
+        friendService.request(사용자_아이디, 아직_친구_요청_전의_사용자_아이디);
+
+        // then
+        final List<Notification> notification = notificationRepository.findAllByReceiverId(아직_친구_요청_전의_사용자_아이디);
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(notification).hasSize(1);
+            softAssertions.assertThat(notification.get(0).getId()).isPositive();
+            softAssertions.assertThat(notification.get(0).getReceiver().getId()).isEqualTo(아직_친구_요청_전의_사용자_아이디);
+            softAssertions.assertThat(notification.get(0).getRequestId()).isEqualTo(사용자_아이디);
+        });
     }
 
     @Test

--- a/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
+++ b/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
@@ -49,7 +49,6 @@ class FriendServiceTest extends FriendServiceTestFixture {
 
     @Test
     void 친구_요청시_요청_상대에게_알림이_저장된다() {
-
         // when
         friendService.request(사용자_아이디, 아직_친구_요청_전의_사용자_아이디);
 

--- a/src/test/java/com/backend/blooming/notification/application/FCMNotificationServiceTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/FCMNotificationServiceTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verify;
 class FCMNotificationServiceTest extends FCMNotificationServiceTestFixture {
 
     @InjectMocks
-    private FCMNotificationService fcmNotificationService;
+    private ProdFCMNotificationService fcmNotificationService;
 
     @Mock
     private DeviceTokenRepository deviceTokenRepository;

--- a/src/test/java/com/backend/blooming/notification/application/FCMNotificationServiceTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/FCMNotificationServiceTest.java
@@ -1,0 +1,74 @@
+package com.backend.blooming.notification.application;
+
+import com.backend.blooming.configuration.IsolateDatabase;
+import com.backend.blooming.devicetoken.infrastructure.repository.DeviceTokenRepository;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.SendResponse;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@IsolateDatabase
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class FCMNotificationServiceTest extends FCMNotificationServiceTestFixture {
+
+    @InjectMocks
+    private FCMNotificationService fcmNotificationService;
+
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+
+    @Mock
+    private FirebaseMessaging firebaseMessaging;
+
+    @Mock
+    private BatchResponse batchResponse;
+
+    @Mock
+    private SendResponse sendResponse;
+
+    @Test
+    void 사용자에게_알림을_보낼때_성공적이라면_아무_로그도_출력되지_않는다() throws FirebaseMessagingException {
+        // given
+        given(deviceTokenRepository.readAllByUserIdAndDeletedIsFalse(사용자_아이디)).willReturn(디바이스_토큰들);
+        given(batchResponse.getFailureCount()).willReturn(0);
+        given(firebaseMessaging.sendAll(anyList())).willReturn(batchResponse);
+
+        // when
+        fcmNotificationService.sendNotification(알림);
+
+        // then
+        verify(sendResponse, never()).isSuccessful();
+    }
+
+    @Test
+    void 사용자에게_알림을_보낼때_알림요청이_실패한_것이_하나라도_있다면_경고_로그가_수행된다() throws FirebaseMessagingException {
+        // given
+        given(deviceTokenRepository.readAllByUserIdAndDeletedIsFalse(사용자_아이디)).willReturn(디바이스_토큰들);
+        given(batchResponse.getFailureCount()).willReturn(1);
+        given(sendResponse.isSuccessful()).willReturn(true, false);
+        given(batchResponse.getResponses()).willReturn(List.of(sendResponse));
+        given(firebaseMessaging.sendAll(anyList())).willReturn(batchResponse);
+
+        // when
+        fcmNotificationService.sendNotification(알림);
+
+        // then
+        verify(sendResponse, atLeastOnce()).isSuccessful();
+        verify(batchResponse, times(2)).getFailureCount();
+    }
+}

--- a/src/test/java/com/backend/blooming/notification/application/FCMNotificationServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/application/FCMNotificationServiceTestFixture.java
@@ -1,0 +1,51 @@
+package com.backend.blooming.notification.application;
+
+import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
+import com.backend.blooming.devicetoken.domain.DeviceToken;
+import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.notification.domain.NotificationType;
+import com.backend.blooming.themecolor.domain.ThemeColor;
+import com.backend.blooming.user.domain.Email;
+import com.backend.blooming.user.domain.Name;
+import com.backend.blooming.user.domain.User;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class FCMNotificationServiceTestFixture {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    protected Long 사용자_아이디;
+    protected List<DeviceToken> 디바이스_토큰들;
+    protected Notification 알림;
+
+    @BeforeEach
+    void setUpFixture() {
+        final User 사용자 = User.builder()
+                             .oAuthId("12345")
+                             .oAuthType(OAuthType.KAKAO)
+                             .name(new Name("사용자"))
+                             .email(new Email("test@email.com"))
+                             .color(ThemeColor.BEIGE)
+                             .statusMessage("기존 상태 메시지")
+                             .build();
+        userRepository.save(사용자);
+
+        final DeviceToken 디바이스_토큰1 = new DeviceToken(사용자.getId(), "token1");
+        final DeviceToken 디바이스_토큰2 = new DeviceToken(사용자.getId(), "token2");
+        디바이스_토큰들 = List.of(디바이스_토큰1, 디바이스_토큰2);
+
+        알림 = Notification.builder()
+                         .receiver(사용자)
+                         .title("알림 제목입니다")
+                         .content("알림 내용입니다")
+                         .type(NotificationType.REQUEST_FRIEND)
+                         .requestId(2L)
+                         .build();
+    }
+}

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @IsolateDatabase
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class NotificationServiceTestTest extends NotificationServiceTestFixture {
+class NotificationServiceTest extends NotificationServiceTestFixture {
 
     @Autowired
     private NotificationService notificationService;
@@ -68,7 +68,7 @@ class NotificationServiceTestTest extends NotificationServiceTestFixture {
 
     @Test
     void 특정_사용자의_전체_알림_목록을_조회시_존재하지_않는_사용자라면_예외를_반환한다() {
-        assertThatThrownBy(() -> notificationService.readAllByUserId(존재하지_않는_사용자))
+        assertThatThrownBy(() -> notificationService.readAllByUserId(존재하지_않는_사용자_아이디))
                 .isInstanceOf(NotFoundUserException.class);
     }
 }

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
@@ -31,8 +31,8 @@ public class NotificationServiceTestFixture {
     protected Friend 보낸_친구_요청;
     protected User 친구_요청을_보낸_사용자;
     protected User 친구_요청을_받은_사용자;
-    protected Long 사용자_아이디;
     protected Long 존재하지_않는_사용자 = 999L;
+    protected User 알림이_있는_사용자;
     protected Notification 친구_요청_알림1;
     protected Notification 친구_요청_알림2;
 
@@ -67,8 +67,7 @@ public class NotificationServiceTestFixture {
 
         보낸_친구_요청 = new Friend(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자);
 
-        final User 알림이_있는_사용자 = 친구_요청을_보낸_사용자;
-        사용자_아이디 = 알림이_있는_사용자.getId();
+        알림이_있는_사용자 = 친구_요청을_보낸_사용자;
         final Friend 보낸_친구_요청1 = new Friend(친구_요청을_보낸_사용자1, 알림이_있는_사용자);
         final Friend 보낸_친구_요청2 = new Friend(친구_요청을_보낸_사용자2, 알림이_있는_사용자);
 

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
@@ -29,6 +29,8 @@ public class NotificationServiceTestFixture {
     private NotificationRepository notificationRepository;
 
     protected Friend 보낸_친구_요청;
+    protected User 친구_요청을_보낸_사용자;
+    protected User 친구_요청을_받은_사용자;
     protected Long 사용자_아이디;
     protected Long 존재하지_않는_사용자 = 999L;
     protected Notification 친구_요청_알림1;
@@ -36,18 +38,18 @@ public class NotificationServiceTestFixture {
 
     @BeforeEach
     void setUpFixture() {
-        final User 친구_요청을_보낸_사용자 = User.builder()
-                                       .oAuthId("12345")
-                                       .oAuthType(OAuthType.KAKAO)
-                                       .name(new Name("사용자1"))
-                                       .email(new Email("user1@email.com"))
-                                       .build();
-        final User 친구_요청을_받은_사용자 = User.builder()
-                                       .oAuthId("12346")
-                                       .oAuthType(OAuthType.KAKAO)
-                                       .name(new Name("사용자2"))
-                                       .email(new Email("user2@email.com"))
-                                       .build();
+        친구_요청을_보낸_사용자 = User.builder()
+                            .oAuthId("12345")
+                            .oAuthType(OAuthType.KAKAO)
+                            .name(new Name("사용자1"))
+                            .email(new Email("user1@email.com"))
+                            .build();
+        친구_요청을_받은_사용자 = User.builder()
+                            .oAuthId("12346")
+                            .oAuthType(OAuthType.KAKAO)
+                            .name(new Name("사용자2"))
+                            .email(new Email("user2@email.com"))
+                            .build();
         final User 친구_요청을_보낸_사용자1 = User.builder()
                                         .oAuthId("12347")
                                         .oAuthType(OAuthType.KAKAO)

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
@@ -10,15 +10,12 @@ import com.backend.blooming.user.domain.Name;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
 import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 public class NotificationServiceTestFixture {
 
@@ -40,17 +37,17 @@ public class NotificationServiceTestFixture {
     @BeforeEach
     void setUpFixture() {
         final User 친구_요청을_보낸_사용자 = User.builder()
-                            .oAuthId("12345")
-                            .oAuthType(OAuthType.KAKAO)
-                            .name(new Name("사용자1"))
-                            .email(new Email("user1@email.com"))
-                            .build();
+                                       .oAuthId("12345")
+                                       .oAuthType(OAuthType.KAKAO)
+                                       .name(new Name("사용자1"))
+                                       .email(new Email("user1@email.com"))
+                                       .build();
         final User 친구_요청을_받은_사용자 = User.builder()
-                            .oAuthId("12346")
-                            .oAuthType(OAuthType.KAKAO)
-                            .name(new Name("사용자2"))
-                            .email(new Email("user2@email.com"))
-                            .build();
+                                       .oAuthId("12346")
+                                       .oAuthType(OAuthType.KAKAO)
+                                       .name(new Name("사용자2"))
+                                       .email(new Email("user2@email.com"))
+                                       .build();
         final User 친구_요청을_보낸_사용자1 = User.builder()
                                         .oAuthId("12347")
                                         .oAuthType(OAuthType.KAKAO)

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
@@ -3,6 +3,8 @@ package com.backend.blooming.notification.application;
 import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
 import com.backend.blooming.friend.domain.Friend;
 import com.backend.blooming.friend.infrastructure.repository.FriendRepository;
+import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
 import com.backend.blooming.user.domain.Email;
 import com.backend.blooming.user.domain.Name;
 import com.backend.blooming.user.domain.User;
@@ -14,6 +16,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
+import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
+
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 public class NotificationServiceTestFixture {
@@ -24,28 +28,68 @@ public class NotificationServiceTestFixture {
     @Autowired
     private FriendRepository friendRepository;
 
-    protected User 친구_요청을_보낸_사용자;
-    protected User 친구_요청을_받은_사용자;
+    @Autowired
+    private NotificationRepository notificationRepository;
+
     protected Friend 보낸_친구_요청;
+    protected Long 사용자_아이디;
+    protected Long 존재하지_않는_사용자 = 999L;
+    protected Notification 친구_요청_알림1;
+    protected Notification 친구_요청_알림2;
 
     @BeforeEach
     void setUpFixture() {
-        친구_요청을_보낸_사용자 = User.builder()
+        final User 친구_요청을_보낸_사용자 = User.builder()
                             .oAuthId("12345")
                             .oAuthType(OAuthType.KAKAO)
                             .name(new Name("사용자1"))
                             .email(new Email("user1@email.com"))
                             .build();
-        친구_요청을_받은_사용자 = User.builder()
+        final User 친구_요청을_받은_사용자 = User.builder()
                             .oAuthId("12346")
                             .oAuthType(OAuthType.KAKAO)
                             .name(new Name("사용자2"))
                             .email(new Email("user2@email.com"))
                             .build();
+        final User 친구_요청을_보낸_사용자1 = User.builder()
+                                        .oAuthId("12347")
+                                        .oAuthType(OAuthType.KAKAO)
+                                        .name(new Name("사용자3"))
+                                        .email(new Email("user3@email.com"))
+                                        .build();
+        final User 친구_요청을_보낸_사용자2 = User.builder()
+                                        .oAuthId("12348")
+                                        .oAuthType(OAuthType.KAKAO)
+                                        .name(new Name("사용자4"))
+                                        .email(new Email("user4@email.com"))
+                                        .build();
 
-        userRepository.saveAll(List.of(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자));
+        userRepository.saveAll(List.of(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자, 친구_요청을_보낸_사용자1, 친구_요청을_보낸_사용자2));
 
         보낸_친구_요청 = new Friend(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자);
-        friendRepository.save(보낸_친구_요청);
+
+        final User 알림이_있는_사용자 = 친구_요청을_보낸_사용자;
+        사용자_아이디 = 알림이_있는_사용자.getId();
+        final Friend 보낸_친구_요청1 = new Friend(친구_요청을_보낸_사용자1, 알림이_있는_사용자);
+        final Friend 보낸_친구_요청2 = new Friend(친구_요청을_보낸_사용자2, 알림이_있는_사용자);
+
+        friendRepository.saveAll(List.of(보낸_친구_요청, 보낸_친구_요청1, 보낸_친구_요청2));
+
+        친구_요청_알림1 = Notification.builder()
+                                .receiver(알림이_있는_사용자)
+                                .title(REQUEST_FRIEND.getTitle())
+                                .content(REQUEST_FRIEND.getContentByFormat(친구_요청을_보낸_사용자1.getName()))
+                                .type(REQUEST_FRIEND)
+                                .requestId(친구_요청을_보낸_사용자1.getId())
+                                .build();
+        친구_요청_알림2 = Notification.builder()
+                                .receiver(알림이_있는_사용자)
+                                .title(REQUEST_FRIEND.getTitle())
+                                .content(REQUEST_FRIEND.getContentByFormat(친구_요청을_보낸_사용자2.getName()))
+                                .type(REQUEST_FRIEND)
+                                .requestId(친구_요청을_보낸_사용자2.getId())
+                                .build();
+
+        notificationRepository.saveAll(List.of(친구_요청_알림1, 친구_요청_알림2));
     }
 }

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
@@ -31,7 +31,7 @@ public class NotificationServiceTestFixture {
     protected Friend 보낸_친구_요청;
     protected User 친구_요청을_보낸_사용자;
     protected User 친구_요청을_받은_사용자;
-    protected Long 존재하지_않는_사용자 = 999L;
+    protected Long 존재하지_않는_사용자_아이디 = 999L;
     protected User 알림이_있는_사용자;
     protected Notification 친구_요청_알림1;
     protected Notification 친구_요청_알림2;

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
@@ -1,0 +1,51 @@
+package com.backend.blooming.notification.application;
+
+import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
+import com.backend.blooming.friend.domain.Friend;
+import com.backend.blooming.friend.infrastructure.repository.FriendRepository;
+import com.backend.blooming.user.domain.Email;
+import com.backend.blooming.user.domain.Name;
+import com.backend.blooming.user.domain.User;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class NotificationServiceTestFixture {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+    protected User 친구_요청을_보낸_사용자;
+    protected User 친구_요청을_받은_사용자;
+    protected Friend 보낸_친구_요청;
+
+    @BeforeEach
+    void setUpFixture() {
+        친구_요청을_보낸_사용자 = User.builder()
+                            .oAuthId("12345")
+                            .oAuthType(OAuthType.KAKAO)
+                            .name(new Name("사용자1"))
+                            .email(new Email("user1@email.com"))
+                            .build();
+        친구_요청을_받은_사용자 = User.builder()
+                            .oAuthId("12346")
+                            .oAuthType(OAuthType.KAKAO)
+                            .name(new Name("사용자2"))
+                            .email(new Email("user2@email.com"))
+                            .build();
+
+        userRepository.saveAll(List.of(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자));
+
+        보낸_친구_요청 = new Friend(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자);
+        friendRepository.save(보낸_친구_요청);
+    }
+}

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestTest.java
@@ -6,6 +6,7 @@ import com.backend.blooming.notification.domain.Notification;
 import com.backend.blooming.notification.domain.NotificationType;
 import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -27,6 +28,9 @@ class NotificationServiceTestTest extends NotificationServiceTestFixture {
     @Autowired
     private NotificationRepository notificationRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @Test
     void 친구_요청에_대한_알림을_저장한다() {
         // when
@@ -41,13 +45,14 @@ class NotificationServiceTestTest extends NotificationServiceTestFixture {
             softAssertions.assertThat(notification.getContent()).contains(친구_요청을_보낸_사용자.getName());
             softAssertions.assertThat(notification.getType()).isEqualTo(NotificationType.REQUEST_FRIEND);
             softAssertions.assertThat(notification.getRequestId()).isEqualTo(친구_요청을_보낸_사용자.getId());
+            softAssertions.assertThat(친구_요청을_받은_사용자.isNewAlarm()).isTrue();
         });
     }
 
     @Test
     void 특정_사용자의_전체_알림_목록을_조회한다() {
         // when
-        final ReadNotificationsDto actual = notificationService.readAllByUserId(사용자_아이디);
+        final ReadNotificationsDto actual = notificationService.readAllByUserId(알림이_있는_사용자.getId());
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -57,6 +62,7 @@ class NotificationServiceTestTest extends NotificationServiceTestFixture {
             softAssertions.assertThat(notifications.get(0).title()).isEqualTo(친구_요청_알림1.getTitle());
             softAssertions.assertThat(notifications.get(1).id()).isEqualTo(친구_요청_알림2.getId());
             softAssertions.assertThat(notifications.get(1).title()).isEqualTo(친구_요청_알림2.getTitle());
+            softAssertions.assertThat(알림이_있는_사용자.isNewAlarm()).isFalse();
         });
     }
 

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestTest.java
@@ -2,8 +2,11 @@ package com.backend.blooming.notification.application;
 
 import com.backend.blooming.configuration.IsolateDatabase;
 import com.backend.blooming.notification.application.dto.ReadNotificationsDto;
+import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.notification.domain.NotificationType;
+import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
-import org.assertj.core.api.*;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -11,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @IsolateDatabase
@@ -22,13 +24,24 @@ class NotificationServiceTestTest extends NotificationServiceTestFixture {
     @Autowired
     private NotificationService notificationService;
 
+    @Autowired
+    private NotificationRepository notificationRepository;
+
     @Test
     void 친구_요청에_대한_알림을_저장한다() {
         // when
         final Long actual = notificationService.sendRequestFriendNotification(보낸_친구_요청);
 
         // then
-        assertThat(actual).isPositive();
+        final Notification notification = notificationRepository.findById(actual).get();
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).isPositive();
+            softAssertions.assertThat(notification.getReceiver().getId()).isEqualTo(친구_요청을_받은_사용자.getId());
+            softAssertions.assertThat(notification.getTitle()).isEqualTo(NotificationType.REQUEST_FRIEND.getTitle());
+            softAssertions.assertThat(notification.getContent()).contains(친구_요청을_보낸_사용자.getName());
+            softAssertions.assertThat(notification.getType()).isEqualTo(NotificationType.REQUEST_FRIEND);
+            softAssertions.assertThat(notification.getRequestId()).isEqualTo(친구_요청을_보낸_사용자.getId());
+        });
     }
 
     @Test

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestTest.java
@@ -1,12 +1,18 @@
 package com.backend.blooming.notification.application;
 
 import com.backend.blooming.configuration.IsolateDatabase;
+import com.backend.blooming.notification.application.dto.ReadNotificationsDto;
+import com.backend.blooming.user.application.exception.NotFoundUserException;
+import org.assertj.core.api.*;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @IsolateDatabase
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -23,5 +29,27 @@ class NotificationServiceTestTest extends NotificationServiceTestFixture {
 
         // then
         assertThat(actual).isPositive();
+    }
+
+    @Test
+    void 특정_사용자의_전체_알림_목록을_조회한다() {
+        // when
+        final ReadNotificationsDto actual = notificationService.readAllByUserId(사용자_아이디);
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            final List<ReadNotificationsDto.ReadNotificationDto> notifications = actual.notifications();
+            softAssertions.assertThat(notifications).hasSize(2);
+            softAssertions.assertThat(notifications.get(0).id()).isEqualTo(친구_요청_알림1.getId());
+            softAssertions.assertThat(notifications.get(0).title()).isEqualTo(친구_요청_알림1.getTitle());
+            softAssertions.assertThat(notifications.get(1).id()).isEqualTo(친구_요청_알림2.getId());
+            softAssertions.assertThat(notifications.get(1).title()).isEqualTo(친구_요청_알림2.getTitle());
+        });
+    }
+
+    @Test
+    void 특정_사용자의_전체_알림_목록을_조회시_존재하지_않는_사용자라면_예외를_반환한다() {
+        assertThatThrownBy(() -> notificationService.readAllByUserId(존재하지_않는_사용자))
+                .isInstanceOf(NotFoundUserException.class);
     }
 }

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestTest.java
@@ -1,0 +1,27 @@
+package com.backend.blooming.notification.application;
+
+import com.backend.blooming.configuration.IsolateDatabase;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IsolateDatabase
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class NotificationServiceTestTest extends NotificationServiceTestFixture {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Test
+    void 친구_요청에_대한_알림을_저장한다() {
+        // when
+        final Long actual = notificationService.sendRequestFriendNotification(보낸_친구_요청);
+
+        // then
+        assertThat(actual).isPositive();
+    }
+}

--- a/src/test/java/com/backend/blooming/notification/application/util/NotificationKeyTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/util/NotificationKeyTest.java
@@ -1,0 +1,36 @@
+package com.backend.blooming.notification.application.util;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class NotificationKeyTest {
+
+    @ParameterizedTest
+    @MethodSource("provideNotificationKey")
+    void 알림_요청_키_이름을_반환한다(final NotificationKey notificationKey, final String expect) {
+        // when
+        final String actual = notificationKey.getValue();
+
+        // then
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    static Stream<Arguments> provideNotificationKey() {
+        return Stream.of(
+                arguments(NotificationKey.TITLE, "title"),
+                arguments(NotificationKey.BODY, "body"),
+                arguments(NotificationKey.TYPE, "type"),
+                arguments(NotificationKey.REQUEST_ID, "requestId")
+        );
+    }
+}

--- a/src/test/java/com/backend/blooming/notification/domain/NotificationTypeTest.java
+++ b/src/test/java/com/backend/blooming/notification/domain/NotificationTypeTest.java
@@ -1,0 +1,24 @@
+package com.backend.blooming.notification.domain;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class NotificationTypeTest {
+
+    @Test
+    void 알림_요청의_내용을_원하는_값을_포함해_반환한다() {
+        // given
+        final String name = "사용자";
+
+        // when
+        final String actual = NotificationType.REQUEST_FRIEND.getContentByFormat(name);
+
+        // then
+        assertThat(actual).isEqualTo("사용자님이 회원님에게 친구 신청을 요청했습니다.");
+    }
+}

--- a/src/test/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepositoryTest.java
@@ -21,7 +21,7 @@ class NotificationRepositoryTest extends NotificationRepositoryTestFixture {
     @Test
     void 특정_사용자_아이디의_전체_알림_목록을_조회한다() {
         // when
-        final List<Notification> actual = notificationRepository.readAllByReceiverId(사용자_아이디);
+        final List<Notification> actual = notificationRepository.findAllByReceiverId(사용자_아이디);
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {

--- a/src/test/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.backend.blooming.notification.infrastructure.repository;
+
+import com.backend.blooming.configuration.IsolateDatabase;
+import com.backend.blooming.notification.domain.Notification;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+@IsolateDatabase
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class NotificationRepositoryTest extends NotificationRepositoryTestFixture {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Test
+    void 특정_사용자_아이디의_전체_알림_목록을_조회한다() {
+        // when
+        final List<Notification> actual = notificationRepository.readAllByReceiverId(사용자_아이디);
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(2);
+            softAssertions.assertThat(actual.get(0).getId()).isPositive();
+            softAssertions.assertThat(actual.get(0).getReceiver().getId()).isEqualTo(사용자_아이디);
+            softAssertions.assertThat(actual.get(0).getTitle()).isEqualTo(알림1.getTitle());
+            softAssertions.assertThat(actual.get(1).getId()).isPositive();
+            softAssertions.assertThat(actual.get(1).getReceiver().getId()).isEqualTo(사용자_아이디);
+            softAssertions.assertThat(actual.get(1).getTitle()).isEqualTo(알림2.getTitle());
+        });
+    }
+}

--- a/src/test/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepositoryTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepositoryTestFixture.java
@@ -7,15 +7,12 @@ import com.backend.blooming.user.domain.Name;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
 import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 public class NotificationRepositoryTestFixture {
 

--- a/src/test/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepositoryTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/infrastructure/repository/NotificationRepositoryTestFixture.java
@@ -1,0 +1,61 @@
+package com.backend.blooming.notification.infrastructure.repository;
+
+import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
+import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.user.domain.Email;
+import com.backend.blooming.user.domain.Name;
+import com.backend.blooming.user.domain.User;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class NotificationRepositoryTestFixture {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    protected Long 사용자_아이디;
+    protected Notification 알림1;
+    protected Notification 알림2;
+
+    @BeforeEach
+    void setUpFixture() {
+        final User 사용자 = User.builder()
+                             .oAuthId("12345")
+                             .oAuthType(OAuthType.KAKAO)
+                             .name(new Name("사용자1"))
+                             .email(new Email("user1@email.com"))
+                             .build();
+
+        userRepository.saveAll(List.of(사용자));
+        사용자_아이디 = 사용자.getId();
+
+        알림1 = Notification.builder()
+                          .receiver(사용자)
+                          .title("제목1")
+                          .content("제목1에 대한 내용입니다.")
+                          .type(REQUEST_FRIEND)
+                          .requestId(99L)
+                          .build();
+        알림2 = Notification.builder()
+                          .receiver(사용자)
+                          .title("제목2")
+                          .content("제목2에 대한 내용입니다.")
+                          .type(REQUEST_FRIEND)
+                          .requestId(100L)
+                          .build();
+
+        notificationRepository.saveAll(List.of(알림1, 알림2));
+    }
+}

--- a/src/test/java/com/backend/blooming/notification/presentation/NotificationControllerTest.java
+++ b/src/test/java/com/backend/blooming/notification/presentation/NotificationControllerTest.java
@@ -84,11 +84,9 @@ class NotificationControllerTest extends NotificationControllerTestFixture {
                                 fieldWithPath("notifications").type(JsonFieldType.ARRAY).description("사용자의 알림 목록"),
                                 fieldWithPath("notifications.[].id").type(JsonFieldType.NUMBER).description("알림 아이디"),
                                 fieldWithPath("notifications.[].title").type(JsonFieldType.STRING).description("알림 제목"),
-                                fieldWithPath("notifications.[].content").type(JsonFieldType.STRING)
-                                                                         .description("알림 내용"),
+                                fieldWithPath("notifications.[].content").type(JsonFieldType.STRING).description("알림 내용"),
                                 fieldWithPath("notifications.[].type").type(JsonFieldType.STRING).description("알림 타입"),
-                                fieldWithPath("notifications.[].requestId").type(JsonFieldType.NUMBER)
-                                                                           .description("알림 수락 시 처리를 위한 아이디")
+                                fieldWithPath("notifications.[].requestId").type(JsonFieldType.NUMBER).description("알림 수락 시 처리를 위한 아이디")
                         )
                 )
         );

--- a/src/test/java/com/backend/blooming/notification/presentation/NotificationControllerTest.java
+++ b/src/test/java/com/backend/blooming/notification/presentation/NotificationControllerTest.java
@@ -1,0 +1,96 @@
+package com.backend.blooming.notification.presentation;
+
+import com.backend.blooming.authentication.infrastructure.jwt.TokenProvider;
+import com.backend.blooming.authentication.presentation.argumentresolver.AuthenticatedThreadLocal;
+import com.backend.blooming.common.RestDocsConfiguration;
+import com.backend.blooming.notification.application.NotificationService;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+@Import({RestDocsConfiguration.class, AuthenticatedThreadLocal.class})
+@AutoConfigureRestDocs
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class NotificationControllerTest extends NotificationControllerTestFixture {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private RestDocumentationResultHandler restDocs;
+
+    @Test
+    void 사용자의_알림_목록을_조회한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(사용자_아이디)).willReturn(true);
+        given(notificationService.readAllByUserId(사용자_아이디)).willReturn(알림_목록_정보_dto);
+
+        // when & then
+        mockMvc.perform(get("/notifications")
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+        ).andExpectAll(
+                status().isOk(),
+                jsonPath("$.notifications.[0].id", is(알림_정보_dto1.id()), Long.class),
+                jsonPath("$.notifications.[0].title", is(알림_정보_dto1.title())),
+                jsonPath("$.notifications.[0].content", is(알림_정보_dto1.content())),
+                jsonPath("$.notifications.[0].type", is(알림_정보_dto1.type().name())),
+                jsonPath("$.notifications.[0].requestId", is(알림_정보_dto1.requestId()), Long.class),
+                jsonPath("$.notifications.[1].id", is(알림_정보_dto2.id()), Long.class),
+                jsonPath("$.notifications.[1].title", is(알림_정보_dto2.title())),
+                jsonPath("$.notifications.[1].content", is(알림_정보_dto2.content())),
+                jsonPath("$.notifications.[1].type", is(알림_정보_dto2.type().name())),
+                jsonPath("$.notifications.[1].requestId", is(알림_정보_dto2.requestId()), Long.class)
+        ).andDo(print()).andDo(
+                restDocs.document(
+                        requestHeaders(
+                                headerWithName("X-API-VERSION").description("요청 버전"),
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("notifications").type(JsonFieldType.ARRAY).description("사용자의 알림 목록"),
+                                fieldWithPath("notifications.[].id").type(JsonFieldType.NUMBER).description("알림 아이디"),
+                                fieldWithPath("notifications.[].title").type(JsonFieldType.STRING).description("알림 제목"),
+                                fieldWithPath("notifications.[].content").type(JsonFieldType.STRING)
+                                                                         .description("알림 내용"),
+                                fieldWithPath("notifications.[].type").type(JsonFieldType.STRING).description("알림 타입"),
+                                fieldWithPath("notifications.[].requestId").type(JsonFieldType.NUMBER)
+                                                                           .description("알림 수락 시 처리를 위한 아이디")
+                        )
+                )
+        );
+    }
+}

--- a/src/test/java/com/backend/blooming/notification/presentation/NotificationControllerTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/presentation/NotificationControllerTestFixture.java
@@ -1,0 +1,35 @@
+package com.backend.blooming.notification.presentation;
+
+import com.backend.blooming.authentication.infrastructure.jwt.TokenType;
+import com.backend.blooming.authentication.infrastructure.jwt.dto.AuthClaims;
+import com.backend.blooming.notification.application.dto.ReadNotificationsDto;
+import com.backend.blooming.notification.domain.NotificationType;
+
+import java.util.List;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class NotificationControllerTestFixture {
+
+    protected TokenType 액세스_토큰_타입 = TokenType.ACCESS;
+    protected String 액세스_토큰 = "Bearer access_token";
+    protected Long 사용자_아이디 = 1L;
+    protected AuthClaims 사용자_토큰_정보 = new AuthClaims(사용자_아이디);
+
+    protected ReadNotificationsDto.ReadNotificationDto 알림_정보_dto1 =
+            new ReadNotificationsDto.ReadNotificationDto(
+                    1L,
+                    "알림 1",
+                    "알림 1에 대한 내용입니다.",
+                    NotificationType.REQUEST_FRIEND,
+                    2L
+            );
+    protected ReadNotificationsDto.ReadNotificationDto 알림_정보_dto2 =
+            new ReadNotificationsDto.ReadNotificationDto(
+                    2L,
+                    "알림 2",
+                    "알림 2에 대한 내용입니다.",
+                    NotificationType.REQUEST_FRIEND,
+                    3L
+            );
+    protected ReadNotificationsDto 알림_목록_정보_dto = new ReadNotificationsDto(List.of(알림_정보_dto1, 알림_정보_dto2));
+}

--- a/src/test/java/com/backend/blooming/user/domain/UserTest.java
+++ b/src/test/java/com/backend/blooming/user/domain/UserTest.java
@@ -102,6 +102,24 @@ class UserTest extends UserTestFixture {
     }
 
     @Test
+    void 새로운_알림_여부를_참으로_수정한다() {
+        // given
+        final User user = User.builder()
+                              .oAuthId("12345")
+                              .oAuthType(OAuthType.KAKAO)
+                              .name(new Name("사용자"))
+                              .email(new Email("user@email.com"))
+                              .color(ThemeColor.BEIGE)
+                              .build();
+
+        // when
+        user.updateNewAlarm(true);
+
+        // then
+        assertThat(user.isNewAlarm()).isTrue();
+    }
+
+    @Test
     void 이메일_조회시_이메일_값을_반환한다() {
         // given
         final User user = User.builder()

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    default: test
+
   datasource:
     url: jdbc:h2:mem:testdb
     username: sa


### PR DESCRIPTION
- closed #27 

## 구현 내용
FCM을 사용한 알림 기능에 대해 구현해 보았습니다.
빠른 구현을 위해 현재는 서비스로 얽혀있는 상태로 좋지 않은 구조지만, 기초 구현이 끝난 이후 고도화 작업 시 Event를 사용해 개선해 보도록 하겠습니다.

디바이스 토큰은 사용자 별로 한 개가 아닌 여러 개를 저장할 수 있도록 했습니다.
이는 사용자가 여러 기기에서 서비스에 로그인할 수도 있기 때문에 위와 같이 진행했습니다.
다만, 추후 로그아웃 및 탈퇴 기능 구현 시 토큰을 삭제하는 기능을 함께 구현할 예정인데, 어떤 기기에서 로그아웃 했는지에 대한 여부를 어떻게 판단할지에 대해선 좀 더 고민해봐야 할 것 같습니다.
만약, 해당 부분에 대해 해결이 안 된다면 사용자 별로 한 개의 디바이스만 등록할 수 있도록 수정될 수도 있음을 미리 알려드립니다.

혹시 코드 중 이해가 안 되는 부분이 있다면 편하게 질문해 주시면 감사하겠습니다!

+) 추가로, FCM의 경우 외부 요청을 통해 진행되는 로직이다 보니, 테스트 시 mocking 처리하여 검증을 진행했습니다. 이로 인해, jacocoTestCoverage에 부합하지 못하는 문제가 발생해, `FCMNotificationService` 관련 클래스만 검증에서 제외했음을 알려드립니다.

## 논의 사항
- todo로도 작성해 두었습니다.
`Notification`의 필드 중 `requestId`의 경우 존재할 수도, 존재하지 않을 수도 있는 값입니다. 
그런데 저희가 컨벤션 상 모든 필드는 Null 입력이 불가능하게 하기로 했는데, 해당 필드도 그렇게 처리하는 것이 적절할지 아직 잘 모르겠어 의견 여쭤봅니다.
만약, null 입력을 불가능하게 한다면, -1과 같은 유효하지 않은 값을 입력해야 할 텐데, 이 부분이 오히려 혼돈을 주거나 requestId를 반환해야 하는 것인지 구분해야 하는 로직이 생겨 불편하지 않을까 하는 생각에 일단 null도 가능한 필드로 만들어둔 상태입니다.
해당 부분에 대해 의견 주시면 감사하겠습니다!