### PR TITLE
사용자 로그아웃, 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/backend/blooming/authentication/application/AuthenticationService.java
+++ b/src/main/java/com/backend/blooming/authentication/application/AuthenticationService.java
@@ -3,6 +3,7 @@ package com.backend.blooming.authentication.application;
 import com.backend.blooming.authentication.application.dto.LoginDto;
 import com.backend.blooming.authentication.application.dto.LoginInformationDto;
 import com.backend.blooming.authentication.application.dto.LoginUserInformationDto;
+import com.backend.blooming.authentication.application.dto.LogoutDto;
 import com.backend.blooming.authentication.application.dto.TokenDto;
 import com.backend.blooming.authentication.application.util.OAuthClientComposite;
 import com.backend.blooming.authentication.infrastructure.exception.InvalidTokenException;
@@ -13,6 +14,7 @@ import com.backend.blooming.authentication.infrastructure.oauth.OAuthClient;
 import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
 import com.backend.blooming.authentication.infrastructure.oauth.dto.UserInformationDto;
 import com.backend.blooming.devicetoken.application.service.DeviceTokenService;
+import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.Email;
 import com.backend.blooming.user.domain.Name;
 import com.backend.blooming.user.domain.User;
@@ -33,6 +35,7 @@ public class AuthenticationService {
     private final OAuthClientComposite oAuthClientComposite;
     private final TokenProvider tokenProvider;
     private final UserRepository userRepository;
+    private final BlackListTokenService blackListTokenService;
     private final DeviceTokenService deviceTokenService;
 
     public LoginInformationDto login(final OAuthType oAuthType, final LoginDto loginDto) {
@@ -108,5 +111,20 @@ public class AuthenticationService {
         }
     }
 
+    public void logout(final Long userId, final LogoutDto logoutDto) {
+        final AuthClaims authClaims = tokenProvider.parseToken(TokenType.REFRESH, logoutDto.refreshToken());
+        final User user = validateAndGetUser(userId, authClaims);
 
+        blackListTokenService.register(logoutDto.refreshToken());
+        deviceTokenService.deactivate(user.getId(), logoutDto.deviceToken());
+    }
+
+    private User validateAndGetUser(final Long userId, final AuthClaims authClaims) {
+        if (!userId.equals(authClaims.userId())) {
+            throw new InvalidTokenException();
+        }
+
+        return userRepository.findById(userId)
+                             .orElseThrow(NotFoundUserException::new);
+    }
 }

--- a/src/main/java/com/backend/blooming/authentication/application/AuthenticationService.java
+++ b/src/main/java/com/backend/blooming/authentication/application/AuthenticationService.java
@@ -127,4 +127,13 @@ public class AuthenticationService {
         return userRepository.findById(userId)
                              .orElseThrow(NotFoundUserException::new);
     }
+
+    public void withdraw(final Long userId, final String refreshToken) {
+        final AuthClaims authClaims = tokenProvider.parseToken(TokenType.REFRESH, refreshToken);
+        final User user = validateAndGetUser(userId, authClaims);
+
+        user.delete();
+        blackListTokenService.register(refreshToken);
+        deviceTokenService.deactivateAllByUserId(user.getId());
+    }
 }

--- a/src/main/java/com/backend/blooming/authentication/application/AuthenticationService.java
+++ b/src/main/java/com/backend/blooming/authentication/application/AuthenticationService.java
@@ -88,7 +88,7 @@ public class AuthenticationService {
 
     private void saveOrActiveToken(final User user, final String deviceToken) {
         if (deviceToken != null && !deviceToken.isEmpty()) {
-            deviceTokenService.saveOrActive(user.getId(), deviceToken);
+            deviceTokenService.saveOrActivate(user.getId(), deviceToken);
         }
     }
 
@@ -107,4 +107,6 @@ public class AuthenticationService {
             throw new InvalidTokenException();
         }
     }
+
+
 }

--- a/src/main/java/com/backend/blooming/authentication/application/BlackListTokenService.java
+++ b/src/main/java/com/backend/blooming/authentication/application/BlackListTokenService.java
@@ -1,0 +1,30 @@
+package com.backend.blooming.authentication.application;
+
+import com.backend.blooming.authentication.application.exception.AlreadyRegisterBlackListTokenException;
+import com.backend.blooming.authentication.domain.BlackListToken;
+import com.backend.blooming.authentication.infrastructure.blacklist.BlackListTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BlackListTokenService {
+
+    private final BlackListTokenRepository blackListTokenRepository;
+
+    public Long register(final String token) {
+        validateToken(token);
+        final BlackListToken blackListToken = new BlackListToken(token);
+
+        return blackListTokenRepository.save(blackListToken)
+                                       .getId();
+    }
+
+    private void validateToken(String token) {
+        if (blackListTokenRepository.existsByToken(token)) {
+            throw new AlreadyRegisterBlackListTokenException();
+        }
+    }
+}

--- a/src/main/java/com/backend/blooming/authentication/application/dto/LogoutDto.java
+++ b/src/main/java/com/backend/blooming/authentication/application/dto/LogoutDto.java
@@ -1,0 +1,4 @@
+package com.backend.blooming.authentication.application.dto;
+
+public record LogoutDto(String refreshToken, String deviceToken) {
+}

--- a/src/main/java/com/backend/blooming/authentication/application/dto/LogoutDto.java
+++ b/src/main/java/com/backend/blooming/authentication/application/dto/LogoutDto.java
@@ -1,4 +1,10 @@
 package com.backend.blooming.authentication.application.dto;
 
+import com.backend.blooming.authentication.presentation.dto.LogoutRequest;
+
 public record LogoutDto(String refreshToken, String deviceToken) {
+
+    public static LogoutDto from(final LogoutRequest logoutRequest) {
+        return new LogoutDto(logoutRequest.refreshToken(), logoutRequest.deviceToken());
+    }
 }

--- a/src/main/java/com/backend/blooming/authentication/application/exception/AlreadyRegisterBlackListTokenException.java
+++ b/src/main/java/com/backend/blooming/authentication/application/exception/AlreadyRegisterBlackListTokenException.java
@@ -1,0 +1,11 @@
+package com.backend.blooming.authentication.application.exception;
+
+import com.backend.blooming.exception.BloomingException;
+import com.backend.blooming.exception.ExceptionMessage;
+
+public class AlreadyRegisterBlackListTokenException extends BloomingException {
+
+    public AlreadyRegisterBlackListTokenException() {
+        super(ExceptionMessage.ALREADY_REGISTER_BLACK_LIST_TOKEN);
+    }
+}

--- a/src/main/java/com/backend/blooming/authentication/configuration/AuthenticationWebMvcConfiguration.java
+++ b/src/main/java/com/backend/blooming/authentication/configuration/AuthenticationWebMvcConfiguration.java
@@ -20,8 +20,7 @@ public class AuthenticationWebMvcConfiguration implements WebMvcConfigurer {
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
-                .addPathPatterns("/**")
-                .excludePathPatterns("/auth/**");
+                .addPathPatterns("/**");
     }
 
     @Override

--- a/src/main/java/com/backend/blooming/authentication/domain/BlackListToken.java
+++ b/src/main/java/com/backend/blooming/authentication/domain/BlackListToken.java
@@ -18,6 +18,7 @@ import lombok.ToString;
 @ToString
 @Table
 public class BlackListToken {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/backend/blooming/authentication/domain/BlackListToken.java
+++ b/src/main/java/com/backend/blooming/authentication/domain/BlackListToken.java
@@ -1,0 +1,30 @@
+package com.backend.blooming.authentication.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id", callSuper = false)
+@ToString
+@Table
+public class BlackListToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String token;
+
+    public BlackListToken(final String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepository.java
+++ b/src/main/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface BlackListTokenRepository extends JpaRepository<BlackListToken, Long> {
 
     Optional<BlackListToken> findByToken(final String token);
+
+    boolean existsByToken(final String token);
 }

--- a/src/main/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepository.java
+++ b/src/main/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepository.java
@@ -1,0 +1,11 @@
+package com.backend.blooming.authentication.infrastructure.blacklist;
+
+import com.backend.blooming.authentication.domain.BlackListToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BlackListTokenRepository extends JpaRepository<BlackListToken, Long> {
+
+    Optional<BlackListToken> findByToken(final String token);
+}

--- a/src/main/java/com/backend/blooming/authentication/presentation/AuthenticationController.java
+++ b/src/main/java/com/backend/blooming/authentication/presentation/AuthenticationController.java
@@ -9,6 +9,7 @@ import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
 import com.backend.blooming.authentication.presentation.anotaion.Authenticated;
 import com.backend.blooming.authentication.presentation.argumentresolver.AuthenticatedUser;
 import com.backend.blooming.authentication.presentation.dto.LogoutRequest;
+import com.backend.blooming.authentication.presentation.dto.WithdrawRequest;
 import com.backend.blooming.authentication.presentation.dto.request.ReissueAccessTokenRequest;
 import com.backend.blooming.authentication.presentation.dto.response.LoginInformationResponse;
 import com.backend.blooming.authentication.presentation.dto.response.SocialLoginRequest;
@@ -16,6 +17,7 @@ import com.backend.blooming.authentication.presentation.dto.response.TokenRespon
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -56,6 +58,17 @@ public class AuthenticationController {
             @RequestBody final LogoutRequest logoutRequest
     ) {
         authenticationService.logout(authenticatedUser.userId(), LogoutDto.from(logoutRequest));
+
+        return ResponseEntity.noContent()
+                             .build();
+    }
+
+    @DeleteMapping(headers = "X-API-VERSION=1")
+    public ResponseEntity<Void> withdraw(
+            @Authenticated final AuthenticatedUser authenticatedUser,
+            @RequestBody final WithdrawRequest withdrawRequest
+    ) {
+        authenticationService.withdraw(authenticatedUser.userId(), withdrawRequest.refreshToken());
 
         return ResponseEntity.noContent()
                              .build();

--- a/src/main/java/com/backend/blooming/authentication/presentation/AuthenticationController.java
+++ b/src/main/java/com/backend/blooming/authentication/presentation/AuthenticationController.java
@@ -3,8 +3,12 @@ package com.backend.blooming.authentication.presentation;
 import com.backend.blooming.authentication.application.AuthenticationService;
 import com.backend.blooming.authentication.application.dto.LoginDto;
 import com.backend.blooming.authentication.application.dto.LoginInformationDto;
+import com.backend.blooming.authentication.application.dto.LogoutDto;
 import com.backend.blooming.authentication.application.dto.TokenDto;
 import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
+import com.backend.blooming.authentication.presentation.anotaion.Authenticated;
+import com.backend.blooming.authentication.presentation.argumentresolver.AuthenticatedUser;
+import com.backend.blooming.authentication.presentation.dto.LogoutRequest;
 import com.backend.blooming.authentication.presentation.dto.request.ReissueAccessTokenRequest;
 import com.backend.blooming.authentication.presentation.dto.response.LoginInformationResponse;
 import com.backend.blooming.authentication.presentation.dto.response.SocialLoginRequest;
@@ -44,5 +48,16 @@ public class AuthenticationController {
         final TokenDto tokenDto = authenticationService.reissueAccessToken(reissueRequest.refreshToken());
 
         return ResponseEntity.ok(TokenResponse.from(tokenDto));
+    }
+
+    @PostMapping(value = "/logout", headers = "X-API-VERSION=1")
+    public ResponseEntity<Void> logout(
+            @Authenticated final AuthenticatedUser authenticatedUser,
+            @RequestBody final LogoutRequest logoutRequest
+    ) {
+        authenticationService.logout(authenticatedUser.userId(), LogoutDto.from(logoutRequest));
+
+        return ResponseEntity.noContent()
+                             .build();
     }
 }

--- a/src/main/java/com/backend/blooming/authentication/presentation/dto/LogoutRequest.java
+++ b/src/main/java/com/backend/blooming/authentication/presentation/dto/LogoutRequest.java
@@ -1,0 +1,4 @@
+package com.backend.blooming.authentication.presentation.dto;
+
+public record LogoutRequest(String refreshToken, String deviceToken) {
+}

--- a/src/main/java/com/backend/blooming/authentication/presentation/dto/WithdrawRequest.java
+++ b/src/main/java/com/backend/blooming/authentication/presentation/dto/WithdrawRequest.java
@@ -1,0 +1,4 @@
+package com.backend.blooming.authentication.presentation.dto;
+
+public record WithdrawRequest(String refreshToken) {
+}

--- a/src/main/java/com/backend/blooming/devicetoken/application/service/DeviceTokenService.java
+++ b/src/main/java/com/backend/blooming/devicetoken/application/service/DeviceTokenService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -16,7 +17,7 @@ public class DeviceTokenService {
 
     private final DeviceTokenRepository deviceTokenRepository;
 
-    public Long saveOrActive(final Long userId, final String token) {
+    public Long saveOrActivate(final Long userId, final String token) {
         final DeviceToken deviceToken = findOrPersistDeviceToken(userId, token);
         activateIfInactive(deviceToken);
 
@@ -45,5 +46,10 @@ public class DeviceTokenService {
         final List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserIdAndActiveIsTrue(userId);
 
         return ReadDeviceTokensDto.from(deviceTokens);
+    }
+
+    public void deactivate(final Long userId, final String token) {
+        final Optional<DeviceToken> deviceToken = deviceTokenRepository.findByUserIdAndToken(userId, token);
+        deviceToken.ifPresent(DeviceToken::deactivate);
     }
 }

--- a/src/main/java/com/backend/blooming/devicetoken/application/service/DeviceTokenService.java
+++ b/src/main/java/com/backend/blooming/devicetoken/application/service/DeviceTokenService.java
@@ -52,4 +52,9 @@ public class DeviceTokenService {
         final Optional<DeviceToken> deviceToken = deviceTokenRepository.findByUserIdAndToken(userId, token);
         deviceToken.ifPresent(DeviceToken::deactivate);
     }
+
+    public void deactivateAllByUserId(final Long userId) {
+        final List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserIdAndActiveIsTrue(userId);
+        deviceTokens.forEach(DeviceToken::deactivate);
+    }
 }

--- a/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
+++ b/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
@@ -16,6 +16,9 @@ public enum ExceptionMessage {
     EXPIRED_TOKEN("기한이 만료된 토큰입니다."),
     UNSUPPORTED_OAUTH_TYPE("지원하지 않는 소셜 로그인 방식입니다."),
 
+    // 블랙 리스트 토큰
+    ALREADY_REGISTER_BLACK_LIST_TOKEN("이미 등록된 블랙 리스트 토큰입니다."),
+
     // 사용자
     NOT_FOUND_USER("사용자를 조회할 수 없습니다."),
     NULL_OR_EMPTY_EMAIL("이메일은 비어있을 수 없습니다."),

--- a/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.backend.blooming.exception;
 
+import com.backend.blooming.authentication.application.exception.AlreadyRegisterBlackListTokenException;
 import com.backend.blooming.authentication.infrastructure.exception.InvalidTokenException;
 import com.backend.blooming.authentication.infrastructure.exception.OAuthException;
 import com.backend.blooming.authentication.infrastructure.exception.UnsupportedOAuthTypeException;
@@ -168,6 +169,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         logger.warn(String.format(LOG_MESSAGE_FORMAT, exception.getClass().getSimpleName(), exception.getMessage()));
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                             .body(new ExceptionResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(AlreadyRegisterBlackListTokenException.class)
+    public ResponseEntity<ExceptionResponse> handleAlreadyRegisterBlackListTokenException(
+            final AlreadyRegisterBlackListTokenException exception
+    ) {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, exception.getClass().getSimpleName(), exception.getMessage()));
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(exception.getMessage()));
     }
 }

--- a/src/test/java/com/backend/blooming/authentication/application/AuthenticationServiceTest.java
+++ b/src/test/java/com/backend/blooming/authentication/application/AuthenticationServiceTest.java
@@ -2,13 +2,18 @@ package com.backend.blooming.authentication.application;
 
 import com.backend.blooming.authentication.application.dto.LoginInformationDto;
 import com.backend.blooming.authentication.application.dto.TokenDto;
+import com.backend.blooming.authentication.domain.BlackListToken;
+import com.backend.blooming.authentication.infrastructure.blacklist.BlackListTokenRepository;
 import com.backend.blooming.authentication.infrastructure.exception.InvalidTokenException;
 import com.backend.blooming.authentication.infrastructure.exception.OAuthException;
 import com.backend.blooming.authentication.infrastructure.exception.UnsupportedOAuthTypeException;
 import com.backend.blooming.authentication.infrastructure.oauth.OAuthClient;
 import com.backend.blooming.configuration.IsolateDatabase;
+import com.backend.blooming.devicetoken.domain.DeviceToken;
+import com.backend.blooming.devicetoken.infrastructure.repository.DeviceTokenRepository;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -33,6 +38,12 @@ class AuthenticationServiceTest extends AuthenticationServiceTestFixture {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private DeviceTokenRepository deviceTokenRepository;
+
+    @Autowired
+    private BlackListTokenRepository blackListTokenRepository;
 
     @Test
     void 로그인시_존재하지_않는_사용자인_경우_해당_사용자를_저장후_토큰_정보를_반환한다() {
@@ -153,6 +164,30 @@ class AuthenticationServiceTest extends AuthenticationServiceTestFixture {
     void 유효하지_않는_타입의_refresh_token으로_access_token_재발행시_예외를_반환한다() {
         // when & then
         assertThatThrownBy(() -> authenticationService.reissueAccessToken(유효하지_않는_타입의_refresh_token))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    void 로그아웃시_디바이스_토큰과_액세스_토큰을_비활성화한다() {
+        // when
+        authenticationService.logout(기존_사용자.getId(), 로그아웃_dto);
+
+        // then
+        final BlackListToken blackListToken = blackListTokenRepository.findByToken(로그아웃_dto.refreshToken()).get();
+        final DeviceToken deviceToken = deviceTokenRepository.findByUserIdAndToken(
+                기존_사용자.getId(),
+                로그아웃_dto.deviceToken()
+        ).get();
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(blackListToken.getToken()).isEqualTo(로그아웃_dto.refreshToken());
+            softAssertions.assertThat(deviceToken.isActive()).isFalse();
+        });
+    }
+
+    @Test
+    void 로그아웃시_리프레시_토큰이_유효하지_않다면_예외를_발생시킨다() {
+        // when & then
+        assertThatThrownBy(() -> authenticationService.logout(기존_사용자.getId(), 유효하지_않은_리프레시_토큰을_갖는_로그아웃_dto))
                 .isInstanceOf(InvalidTokenException.class);
     }
 }

--- a/src/test/java/com/backend/blooming/authentication/application/BlackListTokenServiceTest.java
+++ b/src/test/java/com/backend/blooming/authentication/application/BlackListTokenServiceTest.java
@@ -1,0 +1,35 @@
+package com.backend.blooming.authentication.application;
+
+import com.backend.blooming.authentication.application.exception.AlreadyRegisterBlackListTokenException;
+import com.backend.blooming.configuration.IsolateDatabase;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.*;
+
+@IsolateDatabase
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class BlackListTokenServiceTest extends BlackListTokenServiceTestFixture {
+
+    @Autowired
+    private BlackListTokenService blackListTokenService;
+
+    @Test
+    void 블랙_리스트_토큰을_등록한다() {
+        // when
+        final Long actual = blackListTokenService.register(토큰);
+
+        // then
+        assertThat(actual).isPositive();
+    }
+
+    @Test
+    void 블랙_리스트_토큰_등록시_이미_등록된_토큰이라면_예외를_반환한다() {
+        // when & then
+        assertThatThrownBy(() -> blackListTokenService.register(이미_등록된_토큰))
+                .isInstanceOf(AlreadyRegisterBlackListTokenException.class);
+    }
+}

--- a/src/test/java/com/backend/blooming/authentication/application/BlackListTokenServiceTest.java
+++ b/src/test/java/com/backend/blooming/authentication/application/BlackListTokenServiceTest.java
@@ -7,7 +7,8 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @IsolateDatabase
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/src/test/java/com/backend/blooming/authentication/application/BlackListTokenServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/authentication/application/BlackListTokenServiceTestFixture.java
@@ -1,0 +1,22 @@
+package com.backend.blooming.authentication.application;
+
+import com.backend.blooming.authentication.domain.BlackListToken;
+import com.backend.blooming.authentication.infrastructure.blacklist.BlackListTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class BlackListTokenServiceTestFixture {
+
+    @Autowired
+    private BlackListTokenRepository blackListTokenRepository;
+
+    protected String 토큰 = "refresh token";
+    protected String 이미_등록된_토큰 = "already register refresh token";
+
+    @BeforeEach
+    void setUpFixture() {
+        final BlackListToken 블랙_리스트_토큰 = new BlackListToken(이미_등록된_토큰);
+        blackListTokenRepository.save(블랙_리스트_토큰);
+    }
+}

--- a/src/test/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepositoryTest.java
+++ b/src/test/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepositoryTest.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/src/test/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepositoryTest.java
+++ b/src/test/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepositoryTest.java
@@ -1,0 +1,32 @@
+package com.backend.blooming.authentication.infrastructure.blacklist;
+
+import com.backend.blooming.authentication.domain.BlackListToken;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+@DataJpaTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class BlackListTokenRepositoryTest extends BlackListTokenRepositoryTestFixture {
+
+    @Autowired
+    private BlackListTokenRepository blackListTokenRepository;
+
+    @Test
+    void 블랙_리스트에_특정_토큰이_존재한다면_해당_토큰을_반환한다() {
+        // when
+        final Optional<BlackListToken> actual = blackListTokenRepository.findByToken(블랙_리스트_토큰.getToken());
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).isPresent();
+            softAssertions.assertThat(actual.get().getToken()).isEqualTo(블랙_리스트_토큰.getToken());
+        });
+    }
+}

--- a/src/test/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepositoryTest.java
+++ b/src/test/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepositoryTest.java
@@ -10,6 +10,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.*;
+
 @DataJpaTest
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -28,5 +30,23 @@ class BlackListTokenRepositoryTest extends BlackListTokenRepositoryTestFixture {
             softAssertions.assertThat(actual).isPresent();
             softAssertions.assertThat(actual.get().getToken()).isEqualTo(블랙_리스트_토큰.getToken());
         });
+    }
+
+    @Test
+    void 블랙_리스트에_특정_토큰이_존재한다면_참을_반환한다() {
+        // when
+        final boolean actual = blackListTokenRepository.existsByToken(블랙_리스트_토큰.getToken());
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 블랙_리스트에_특정_토큰이_존재하지_않다면_거짓을_반환한다() {
+        // when
+        final boolean actual = blackListTokenRepository.existsByToken(존재하지_않는_토큰);
+
+        // then
+        assertThat(actual).isFalse();
     }
 }

--- a/src/test/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepositoryTestFixture.java
+++ b/src/test/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepositoryTestFixture.java
@@ -4,8 +4,6 @@ import com.backend.blooming.authentication.domain.BlackListToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.time.LocalDateTime;
-
 @SuppressWarnings("NonAsciiCharacters")
 public class BlackListTokenRepositoryTestFixture {
 
@@ -13,10 +11,11 @@ public class BlackListTokenRepositoryTestFixture {
     private BlackListTokenRepository blackListTokenRepository;
 
     protected BlackListToken 블랙_리스트_토큰;
+    protected String 존재하지_않는_토큰 = "not exist token";
 
     @BeforeEach
     void setUpFixture() {
-        블랙_리스트_토큰 = new BlackListToken("black list token", LocalDateTime.now());
+        블랙_리스트_토큰 = new BlackListToken("black list token");
         blackListTokenRepository.save(블랙_리스트_토큰);
     }
 }

--- a/src/test/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepositoryTestFixture.java
+++ b/src/test/java/com/backend/blooming/authentication/infrastructure/blacklist/BlackListTokenRepositoryTestFixture.java
@@ -1,0 +1,22 @@
+package com.backend.blooming.authentication.infrastructure.blacklist;
+
+import com.backend.blooming.authentication.domain.BlackListToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class BlackListTokenRepositoryTestFixture {
+
+    @Autowired
+    private BlackListTokenRepository blackListTokenRepository;
+
+    protected BlackListToken 블랙_리스트_토큰;
+
+    @BeforeEach
+    void setUpFixture() {
+        블랙_리스트_토큰 = new BlackListToken("black list token", LocalDateTime.now());
+        blackListTokenRepository.save(블랙_리스트_토큰);
+    }
+}

--- a/src/test/java/com/backend/blooming/authentication/presentation/AuthenticationControllerTestFixture.java
+++ b/src/test/java/com/backend/blooming/authentication/presentation/AuthenticationControllerTestFixture.java
@@ -7,6 +7,7 @@ import com.backend.blooming.authentication.application.dto.TokenDto;
 import com.backend.blooming.authentication.infrastructure.jwt.dto.AuthClaims;
 import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
 import com.backend.blooming.authentication.presentation.dto.LogoutRequest;
+import com.backend.blooming.authentication.presentation.dto.WithdrawRequest;
 import com.backend.blooming.authentication.presentation.dto.request.ReissueAccessTokenRequest;
 import com.backend.blooming.authentication.presentation.dto.response.SocialLoginRequest;
 
@@ -36,4 +37,5 @@ public class AuthenticationControllerTestFixture {
     protected AuthClaims 사용자_토큰_정보 = new AuthClaims(사용자_아이디);
     protected LogoutRequest 로그아웃_정보_요청 = new LogoutRequest(서비스_refresh_token, 디바이스_토큰);
     protected LogoutDto 로그아웃_정보_dto = new LogoutDto(서비스_refresh_token, 디바이스_토큰);
+    protected WithdrawRequest 탈퇴_정보_요청 = new WithdrawRequest(서비스_refresh_token);
 }

--- a/src/test/java/com/backend/blooming/authentication/presentation/AuthenticationControllerTestFixture.java
+++ b/src/test/java/com/backend/blooming/authentication/presentation/AuthenticationControllerTestFixture.java
@@ -2,8 +2,11 @@ package com.backend.blooming.authentication.presentation;
 
 import com.backend.blooming.authentication.application.dto.LoginDto;
 import com.backend.blooming.authentication.application.dto.LoginInformationDto;
+import com.backend.blooming.authentication.application.dto.LogoutDto;
 import com.backend.blooming.authentication.application.dto.TokenDto;
+import com.backend.blooming.authentication.infrastructure.jwt.dto.AuthClaims;
 import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
+import com.backend.blooming.authentication.presentation.dto.LogoutRequest;
 import com.backend.blooming.authentication.presentation.dto.request.ReissueAccessTokenRequest;
 import com.backend.blooming.authentication.presentation.dto.response.SocialLoginRequest;
 
@@ -11,8 +14,8 @@ import com.backend.blooming.authentication.presentation.dto.response.SocialLogin
 public class AuthenticationControllerTestFixture {
 
     protected OAuthType oauth_타입 = OAuthType.KAKAO;
-    private String 소셜_액세스_토큰 = "social_access_token";
-    private String 디바이스_토큰 = "device_token";
+    protected String 소셜_액세스_토큰 = "social_access_token";
+    protected String 디바이스_토큰 = "device_token";
     protected LoginDto 로그인_정보 = LoginDto.of(소셜_액세스_토큰, 디바이스_토큰);
     private String 유효하지_않은_소셜_액세스_토큰 = "social_access_token";
     protected LoginDto 유효하지_않은_소셜_액세스_토큰을_가진_로그인_정보 = LoginDto.of(유효하지_않은_소셜_액세스_토큰, 디바이스_토큰);
@@ -28,5 +31,9 @@ public class AuthenticationControllerTestFixture {
     );
     protected String 서비스_refresh_token = "blooming_refresh_token";
     protected ReissueAccessTokenRequest access_token_재발급_요청 = new ReissueAccessTokenRequest(서비스_refresh_token);
-    protected TokenDto 서비스_토큰_정보 = new TokenDto("access token", "refresh token");
+    protected TokenDto 서비스_토큰_정보 = new TokenDto(소셜_액세스_토큰, "refresh token");
+    protected Long 사용자_아이디 = 1L;
+    protected AuthClaims 사용자_토큰_정보 = new AuthClaims(사용자_아이디);
+    protected LogoutRequest 로그아웃_정보_요청 = new LogoutRequest(서비스_refresh_token, 디바이스_토큰);
+    protected LogoutDto 로그아웃_정보_dto = new LogoutDto(서비스_refresh_token, 디바이스_토큰);
 }

--- a/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTest.java
@@ -26,7 +26,7 @@ class DeviceTokenServiceTest extends DeviceTokenServiceTestFixture {
     @Test
     void 디바이스_토큰을_저장한다() {
         // when
-        final Long actual = deviceTokenService.saveOrActive(사용자_아이디, 디바이스_토큰);
+        final Long actual = deviceTokenService.saveOrActivate(사용자_아이디, 디바이스_토큰);
 
         // then
         assertThat(actual).isPositive();
@@ -35,7 +35,7 @@ class DeviceTokenServiceTest extends DeviceTokenServiceTestFixture {
     @Test
     void 디바이스_토큰_저장시_비활성화된_동일한_토큰이_있다면_활성화한다() {
         // when
-        final Long actual = deviceTokenService.saveOrActive(사용자_아이디, 비활성화_디바이스_토큰.getToken());
+        final Long actual = deviceTokenService.saveOrActivate(사용자_아이디, 비활성화_디바이스_토큰.getToken());
 
         // then
         final DeviceToken deviceToken = deviceTokenRepository.findById(actual).get();
@@ -59,5 +59,15 @@ class DeviceTokenServiceTest extends DeviceTokenServiceTestFixture {
             softAssertions.assertThat(actual.deviceTokens().get(1).id()).isEqualTo(디바이스_토큰2.getId());
             softAssertions.assertThat(actual.deviceTokens().get(1).deviceToken()).isEqualTo(디바이스_토큰2.getToken());
         });
+    }
+
+    @Test
+    void 사용자의_특정_디바이스_토큰을_비활성화한다() {
+        // when
+        deviceTokenService.deactivate(사용자_아이디, 디바이스_토큰1.getToken());
+
+        // then
+        final DeviceToken actual = deviceTokenRepository.findByUserIdAndToken(사용자_아이디, 디바이스_토큰1.getToken()).get();
+        assertThat(actual.isActive()).isFalse();
     }
 }

--- a/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/backend/blooming/devicetoken/application/service/DeviceTokenServiceTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IsolateDatabase
@@ -69,5 +71,15 @@ class DeviceTokenServiceTest extends DeviceTokenServiceTestFixture {
         // then
         final DeviceToken actual = deviceTokenRepository.findByUserIdAndToken(사용자_아이디, 디바이스_토큰1.getToken()).get();
         assertThat(actual.isActive()).isFalse();
+    }
+
+    @Test
+    void 사용자의_모든_디바이스_토큰을_비활성화한다() {
+        // when
+        deviceTokenService.deactivateAllByUserId(사용자_아이디);
+
+        // then
+        final List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserIdAndActiveIsTrue(사용자_아이디);
+        assertThat(deviceTokens).isEmpty();
     }
 }


### PR DESCRIPTION
- closed #47 

사용자의 탈퇴와 로그아웃에 대해 구현 완료했습니다.
관련 API는 오늘자(2/4) 회의록에 작성해 두었습니다. 해당 부분 참고해 주시면 감사하겠습니다!
크게 어려운 로직은 없으며, 로그아웃과 탈퇴 로직의 흐름은 각각 아래와 같습니다.

**로그아웃 로직 흐름**
1. 사용자의 refresh 토큰을 블랙리스트 토큰에 등록
2. `로그아웃을 하는 디바이스` 토큰 비활성화

**탈퇴 로직 흐름**
1. 사용자의 삭제 여부를 참으로 변경
2. 사용자의 refresh 토큰을 블랙리스트 토큰에 등록
3. 사용자의 `등록된 모든` 디바이스 토큰 비활성화
* 다만, 탈퇴 시 개인 정보 처리를 어떻게 할 지에 따라 좀 더 추가될 수도 있을 것 같습니다. 이 부분은 회의 이후에 리팩터링하는 방향으로 진행하겠습니다.
+) 회의 결과 개인정보처리 방침은 추후에 회의를 진행하기로 했으며, 그때 정해지면 수정하기로 결정했기에 추가 사항 없이 리뷰 진행해 주시면 됩니다!