### PR TITLE
dev 서버 배포 시 view를 찾지 못하는 문제 해결

### DIFF
--- a/src/main/java/com/backend/blooming/admin/controller/AdminPageController.java
+++ b/src/main/java/com/backend/blooming/admin/controller/AdminPageController.java
@@ -47,7 +47,7 @@ public class AdminPageController {
         model.addAttribute("themes", getThemes());
         model.addAttribute("users", getUsers());
 
-        return "/admin/test";
+        return "admin/test";
     }
 
     private static List<String> getThemes() {

--- a/src/test/java/com/backend/blooming/admin/controller/AdminPageControllerTest.java
+++ b/src/test/java/com/backend/blooming/admin/controller/AdminPageControllerTest.java
@@ -63,8 +63,8 @@ class AdminPageControllerTest extends AdminPageControllerTestFixture {
         mockMvc.perform(get("/admin"))
                .andExpectAll(
                        status().isOk(),
-                       view().name("/admin/test"),
-                       model().attributeExists("themes")
+                       view().name("admin/test"),
+                       model().attributeExists("themes", "users")
                );
     }
 


### PR DESCRIPTION
- closed #53 

local에서 진행할 때는 괜찮았는데, 배포한 후에는 view 경로를 찾지 못하는 문제가 발생해 이를 해결했습니다!
view 경로 시작 시 `/`를 제거해야 한다고 해 해당 부분만 수정하였고, 잘 작동하는 것 확인했습니다.