### PR TITLE
사용자 정보 수정 시 이름 중복 문제에 대한 예외 처리 추가

### DIFF
--- a/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
+++ b/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
@@ -26,6 +26,7 @@ public enum ExceptionMessage {
     INVALID_EMAIL_FORMAT("이메일 형식에 어긋났습니다."),
     NULL_OR_EMPTY_NAME("이름은 비어있을 수 없습니다."),
     LONGER_THAN_MAXIMUM_NAME("이름의 최대 길이를 초과했습니다."),
+    DUPLICATE_USER_NAME("이미 존재하는 사용자 이름입니다."),
 
     // 테마 색상
     UNSUPPORTED_THEME_COLOR("지원하지 않는 테마 색상입니다."),

--- a/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
 import com.backend.blooming.themecolor.domain.exception.UnsupportedThemeColorException;
+import com.backend.blooming.user.application.exception.DuplicateUserNameExcpetion;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -199,6 +200,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(AlreadyRegisterBlackListTokenException.class)
     public ResponseEntity<ExceptionResponse> handleAlreadyRegisterBlackListTokenException(
             final AlreadyRegisterBlackListTokenException exception
+    ) {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, exception.getClass().getSimpleName(), exception.getMessage()));
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                             .body(new ExceptionResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(DuplicateUserNameExcpetion.class)
+    public ResponseEntity<ExceptionResponse> handleDuplicateUserNameExcpetion(
+            final DuplicateUserNameExcpetion exception
     ) {
         logger.warn(String.format(LOG_MESSAGE_FORMAT, exception.getClass().getSimpleName(), exception.getMessage()));
 

--- a/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
@@ -14,7 +14,7 @@ import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
 import com.backend.blooming.themecolor.domain.exception.UnsupportedThemeColorException;
-import com.backend.blooming.user.application.exception.DuplicateUserNameExcpetion;
+import com.backend.blooming.user.application.exception.DuplicateUserNameException;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -207,9 +207,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                              .body(new ExceptionResponse(exception.getMessage()));
     }
 
-    @ExceptionHandler(DuplicateUserNameExcpetion.class)
+    @ExceptionHandler(DuplicateUserNameException.class)
     public ResponseEntity<ExceptionResponse> handleDuplicateUserNameExcpetion(
-            final DuplicateUserNameExcpetion exception
+            final DuplicateUserNameException exception
     ) {
         logger.warn(String.format(LOG_MESSAGE_FORMAT, exception.getClass().getSimpleName(), exception.getMessage()));
 

--- a/src/main/java/com/backend/blooming/user/application/UserService.java
+++ b/src/main/java/com/backend/blooming/user/application/UserService.java
@@ -4,7 +4,7 @@ import com.backend.blooming.themecolor.domain.ThemeColor;
 import com.backend.blooming.user.application.dto.ReadUserDto;
 import com.backend.blooming.user.application.dto.UpdateUserDto;
 import com.backend.blooming.user.application.dto.ReadUsersWithFriendsStatusDto;
-import com.backend.blooming.user.application.exception.DuplicateUserNameExcpetion;
+import com.backend.blooming.user.application.exception.DuplicateUserNameException;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.Name;
 import com.backend.blooming.user.domain.User;
@@ -71,7 +71,7 @@ public class UserService {
             return;
         }
         if (userRepository.existsByNameAndDeletedIsFalse(name)) {
-            throw new DuplicateUserNameExcpetion();
+            throw new DuplicateUserNameException();
         }
     }
 }

--- a/src/main/java/com/backend/blooming/user/application/UserService.java
+++ b/src/main/java/com/backend/blooming/user/application/UserService.java
@@ -4,6 +4,7 @@ import com.backend.blooming.themecolor.domain.ThemeColor;
 import com.backend.blooming.user.application.dto.ReadUserDto;
 import com.backend.blooming.user.application.dto.UpdateUserDto;
 import com.backend.blooming.user.application.dto.ReadUsersWithFriendsStatusDto;
+import com.backend.blooming.user.application.exception.DuplicateUserNameExcpetion;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.Name;
 import com.backend.blooming.user.domain.User;
@@ -53,6 +54,7 @@ public class UserService {
     private void updateUserByRequest(final User user, final UpdateUserDto updateUserDto) {
         if (updateUserDto.name() != null) {
             final Name updateName = new Name(updateUserDto.name());
+            validateDuplicateName(user, updateName);
             user.updateName(updateName);
         }
         if (updateUserDto.color() != null) {
@@ -61,6 +63,15 @@ public class UserService {
         }
         if (updateUserDto.statusMessage() != null) {
             user.updateStatusMessage(updateUserDto.statusMessage());
+        }
+    }
+
+    private void validateDuplicateName(final User user, final Name name) {
+        if (user.isSameName(name)) {
+            return;
+        }
+        if (userRepository.existsByNameAndDeletedIsFalse(name)) {
+            throw new DuplicateUserNameExcpetion();
         }
     }
 }

--- a/src/main/java/com/backend/blooming/user/application/exception/DuplicateUserNameException.java
+++ b/src/main/java/com/backend/blooming/user/application/exception/DuplicateUserNameException.java
@@ -3,10 +3,9 @@ package com.backend.blooming.user.application.exception;
 import com.backend.blooming.exception.BloomingException;
 import com.backend.blooming.exception.ExceptionMessage;
 
-public class DuplicateUserNameExcpetion extends BloomingException {
+public class DuplicateUserNameException extends BloomingException {
 
-
-    public DuplicateUserNameExcpetion() {
+    public DuplicateUserNameException() {
         super(ExceptionMessage.DUPLICATE_USER_NAME);
     }
 }

--- a/src/main/java/com/backend/blooming/user/application/exception/DuplicateUserNameExcpetion.java
+++ b/src/main/java/com/backend/blooming/user/application/exception/DuplicateUserNameExcpetion.java
@@ -1,0 +1,12 @@
+package com.backend.blooming.user.application.exception;
+
+import com.backend.blooming.exception.BloomingException;
+import com.backend.blooming.exception.ExceptionMessage;
+
+public class DuplicateUserNameExcpetion extends BloomingException {
+
+
+    public DuplicateUserNameExcpetion() {
+        super(ExceptionMessage.DUPLICATE_USER_NAME);
+    }
+}

--- a/src/main/java/com/backend/blooming/user/domain/Name.java
+++ b/src/main/java/com/backend/blooming/user/domain/Name.java
@@ -34,4 +34,8 @@ public class Name {
             throw new MemberException.LongerThanMaximumNameLengthException();
         }
     }
+
+    public boolean isSame(final Name value) {
+        return this.equals(value);
+    }
 }

--- a/src/main/java/com/backend/blooming/user/domain/User.java
+++ b/src/main/java/com/backend/blooming/user/domain/User.java
@@ -113,6 +113,10 @@ public class User extends BaseTimeEntity {
         this.newAlarm = newAlarm;
     }
 
+    public boolean isSameName(final Name name) {
+        return this.name.isSame(name);
+    }
+
     public String getEmail() {
         return email.getValue();
     }

--- a/src/main/java/com/backend/blooming/user/infrastructure/repository/UserRepository.java
+++ b/src/main/java/com/backend/blooming/user/infrastructure/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.backend.blooming.user.infrastructure.repository;
 
 import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
+import com.backend.blooming.user.domain.Name;
 import com.backend.blooming.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -20,6 +21,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByIdAndDeletedIsFalse(final Long userId);
 
     boolean existsByIdAndDeletedIsFalse(final Long userId);
+
+    boolean existsByNameAndDeletedIsFalse(final Name name);
 
     @Query("""
             SELECT u

--- a/src/test/java/com/backend/blooming/user/application/UserServiceTest.java
+++ b/src/test/java/com/backend/blooming/user/application/UserServiceTest.java
@@ -3,7 +3,7 @@ package com.backend.blooming.user.application;
 import com.backend.blooming.configuration.IsolateDatabase;
 import com.backend.blooming.user.application.dto.ReadUserDto;
 import com.backend.blooming.user.application.dto.ReadUsersWithFriendsStatusDto;
-import com.backend.blooming.user.application.exception.DuplicateUserNameExcpetion;
+import com.backend.blooming.user.application.exception.DuplicateUserNameException;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.infrastructure.repository.dto.FriendsStatus;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -116,7 +116,7 @@ class UserServiceTest extends UserServiceTestFixture {
     void 사용자_이름_수정시_이미_존재하는_이름이라면_예외를_반환한다() {
         // when & then
         assertThatThrownBy(() -> userService.updateById(사용자_아이디, 이미_존재하는_이름으로_수정한_dto))
-                .isInstanceOf(DuplicateUserNameExcpetion.class);
+                .isInstanceOf(DuplicateUserNameException.class);
     }
 
     @Test

--- a/src/test/java/com/backend/blooming/user/application/UserServiceTest.java
+++ b/src/test/java/com/backend/blooming/user/application/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.backend.blooming.user.application;
 import com.backend.blooming.configuration.IsolateDatabase;
 import com.backend.blooming.user.application.dto.ReadUserDto;
 import com.backend.blooming.user.application.dto.ReadUsersWithFriendsStatusDto;
+import com.backend.blooming.user.application.exception.DuplicateUserNameExcpetion;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.infrastructure.repository.dto.FriendsStatus;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -96,6 +97,26 @@ class UserServiceTest extends UserServiceTestFixture {
             softAssertions.assertThat(actual.color()).isEqualTo(기존_테마_색상.getCode());
             softAssertions.assertThat(actual.statusMessage()).isEqualTo(기존_상태_메시지);
         });
+    }
+
+    @Test
+    void 사용자가_동일한_이름으로_수정시_예외없이_수정한다() {
+        // when
+        final ReadUserDto actual = userService.updateById(사용자_아이디, 기존_이름으로_수정한_dto);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.name()).isEqualTo(기존_이름);
+            softAssertions.assertThat(actual.color()).isEqualTo(기존_테마_색상.getCode());
+            softAssertions.assertThat(actual.statusMessage()).isEqualTo(기존_상태_메시지);
+        });
+    }
+
+    @Test
+    void 사용자_이름_수정시_이미_존재하는_이름이라면_예외를_반환한다() {
+        // when & then
+        assertThatThrownBy(() -> userService.updateById(사용자_아이디, 이미_존재하는_이름으로_수정한_dto))
+                .isInstanceOf(DuplicateUserNameExcpetion.class);
     }
 
     @Test

--- a/src/test/java/com/backend/blooming/user/application/UserServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/user/application/UserServiceTestFixture.java
@@ -39,6 +39,8 @@ public class UserServiceTestFixture {
     protected String 기존_상태_메시지;
     protected UpdateUserDto 모든_사용자_정보를_수정한_dto = new UpdateUserDto(수정한_이름, 수정한_테마_색상.name(), 수정한_상태_메시지);
     protected UpdateUserDto 이름만_수정한_dto = new UpdateUserDto(수정한_이름, null, null);
+    protected UpdateUserDto 기존_이름으로_수정한_dto;
+    protected UpdateUserDto 이미_존재하는_이름으로_수정한_dto;
     protected UpdateUserDto 테마_색상만_수정한_dto = new UpdateUserDto(null, 수정한_테마_색상.name(), null);
     protected UpdateUserDto 상태_메시지만_수정한_dto = new UpdateUserDto(null, null, 수정한_상태_메시지);
 
@@ -79,6 +81,8 @@ public class UserServiceTestFixture {
         기존_이름 = 사용자.getName();
         기존_테마_색상 = 사용자.getColor();
         기존_상태_메시지 = 사용자.getStatusMessage();
+        기존_이름으로_수정한_dto = new UpdateUserDto(사용자.getName(), null, null);
+        이미_존재하는_이름으로_수정한_dto = new UpdateUserDto(친구인_사용자.getName(), null, null);
 
         final Friend 친구_요청 = new Friend(사용자, 친구인_사용자);
         친구_요청.acceptRequest();

--- a/src/test/java/com/backend/blooming/user/domain/NameTest.java
+++ b/src/test/java/com/backend/blooming/user/domain/NameTest.java
@@ -43,4 +43,31 @@ class NameTest {
         assertThatThrownBy(() -> new Name(invalidNameValue))
                 .isInstanceOf(MemberException.LongerThanMaximumNameLengthException.class);
     }
+
+    @Test
+    void 이름이_동일하다면_참을_반환한다() {
+        // given
+        final String nameValue = "name";
+        final Name name1 = new Name(nameValue);
+        final Name name2 = new Name(nameValue);
+
+        // when
+        final boolean actual = name1.isSame(name2);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 이름이_다르다면_거짓을_반환한다() {
+        // given
+        final Name name1 = new Name("name1");
+        final Name name2 = new Name("name2");
+
+        // when
+        final boolean actual = name1.isSame(name2);
+
+        // then
+        assertThat(actual).isFalse();
+    }
 }

--- a/src/test/java/com/backend/blooming/user/domain/UserTest.java
+++ b/src/test/java/com/backend/blooming/user/domain/UserTest.java
@@ -172,4 +172,42 @@ class UserTest extends UserTestFixture {
         // then
         assertThat(actual).isEqualTo(ThemeColor.BEIGE.getCode());
     }
+
+    @Test
+    void 사용자의_이름과_동일하다면_참을_반환한다() {
+        // given
+        final String userName = "사용자";
+        final User user = User.builder()
+                              .oAuthId("12345")
+                              .oAuthType(OAuthType.KAKAO)
+                              .name(new Name(userName))
+                              .email(new Email("user@email.com"))
+                              .color(ThemeColor.BEIGE)
+                              .build();
+
+        // when
+        final boolean actual = user.isSameName(new Name(userName));
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 사용자의_이름과_다르다면_거짓을_반환한다() {
+        // given
+        final String differentName = "다름";
+        final User user = User.builder()
+                              .oAuthId("12345")
+                              .oAuthType(OAuthType.KAKAO)
+                              .name(new Name("사용자"))
+                              .email(new Email("user@email.com"))
+                              .color(ThemeColor.BEIGE)
+                              .build();
+
+        // when
+        final boolean actual = user.isSameName(new Name(differentName));
+
+        // then
+        assertThat(actual).isFalse();
+    }
 }

--- a/src/test/java/com/backend/blooming/user/infrastructure/repository/UserRepositoryTest.java
+++ b/src/test/java/com/backend/blooming/user/infrastructure/repository/UserRepositoryTest.java
@@ -2,7 +2,6 @@ package com.backend.blooming.user.infrastructure.repository;
 
 import com.backend.blooming.configuration.JpaConfiguration;
 import com.backend.blooming.user.domain.User;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -98,6 +97,33 @@ class UserRepositoryTest extends UserRepositoryTestFixture {
     void 존재하지_않는_사용자_아이디_조회시_거짓을_반환한다() {
         // when
         final boolean actual = userRepository.existsByIdAndDeletedIsFalse(존재하지_않는_사용자_아이디);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void 존재하는_사용자_이름_조회시_참을_반환한다() {
+        // when
+        final boolean actual = userRepository.existsByNameAndDeletedIsFalse(존재하는_사용자_이름);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 삭제된_사용자_이름_조회시_거짓을_반환한다() {
+        // when
+        final boolean actual = userRepository.existsByNameAndDeletedIsFalse(삭제된_사용자_이름);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void 존재하지_않는_사용자_이름_조회시_거짓을_반환한다() {
+        // when
+        final boolean actual = userRepository.existsByNameAndDeletedIsFalse(존재하지_않는_사용자_이름);
 
         // then
         assertThat(actual).isFalse();

--- a/src/test/java/com/backend/blooming/user/infrastructure/repository/UserRepositoryTestFixture.java
+++ b/src/test/java/com/backend/blooming/user/infrastructure/repository/UserRepositoryTestFixture.java
@@ -25,6 +25,9 @@ public class UserRepositoryTestFixture {
     protected Long 사용자_아이디;
     protected Long 삭제된_사용자_아이디;
     protected Long 존재하지_않는_사용자_아이디 = 9999L;
+    protected Name 존재하는_사용자_이름;
+    protected Name 삭제된_사용자_이름;
+    protected Name 존재하지_않는_사용자_이름 = new Name("없어요");
     protected List<Long> 사용자_아이디_목록 = new ArrayList<>();
 
     @BeforeEach
@@ -54,7 +57,9 @@ public class UserRepositoryTestFixture {
         유효한_oAuth_타입 = 사용자.getOAuthType();
 
         사용자_아이디 = 사용자.getId();
+        존재하는_사용자_이름 = new Name(사용자.getName());
         삭제된_사용자_아이디 = 삭제된_사용자.getId();
+        삭제된_사용자_이름 = new Name(삭제된_사용자.getName());
         사용자_아이디_목록.addAll(List.of(사용자_아이디, 사용자2.getId(), 삭제된_사용자_아이디));
     }
 }

--- a/src/test/java/com/backend/blooming/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/backend/blooming/user/presentation/UserControllerTest.java
@@ -296,7 +296,6 @@ class UserControllerTest extends UserControllerTestFixture {
         );
     }
 
-
     @Test
     void 존재하지_않는_사용자_정보_수정시_400을_반환한다() throws Exception {
         // given
@@ -317,9 +316,8 @@ class UserControllerTest extends UserControllerTestFixture {
         );
     }
 
-
     @Test
-    void 이미_존재하는_이름으로_사용자_정보_수정시_404를_반환한다() throws Exception {
+    void 이미_존재하는_이름으로_사용자_정보_수정시_400를_반환한다() throws Exception {
         // given
         given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_아이디)).willReturn(true);

--- a/src/test/java/com/backend/blooming/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/backend/blooming/user/presentation/UserControllerTest.java
@@ -4,7 +4,7 @@ import com.backend.blooming.authentication.infrastructure.jwt.TokenProvider;
 import com.backend.blooming.authentication.presentation.argumentresolver.AuthenticatedThreadLocal;
 import com.backend.blooming.common.RestDocsConfiguration;
 import com.backend.blooming.user.application.UserService;
-import com.backend.blooming.user.application.exception.DuplicateUserNameExcpetion;
+import com.backend.blooming.user.application.exception.DuplicateUserNameException;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -324,7 +324,7 @@ class UserControllerTest extends UserControllerTestFixture {
         given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_아이디)).willReturn(true);
         given(userService.updateById(사용자_아이디, 사용자의_모든_정보_수정_dto))
-                .willThrow(new DuplicateUserNameExcpetion());
+                .willThrow(new DuplicateUserNameException());
 
         // when & then
         mockMvc.perform(patch("/users")

--- a/src/test/java/com/backend/blooming/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/backend/blooming/user/presentation/UserControllerTest.java
@@ -4,6 +4,7 @@ import com.backend.blooming.authentication.infrastructure.jwt.TokenProvider;
 import com.backend.blooming.authentication.presentation.argumentresolver.AuthenticatedThreadLocal;
 import com.backend.blooming.common.RestDocsConfiguration;
 import com.backend.blooming.user.application.UserService;
+import com.backend.blooming.user.application.exception.DuplicateUserNameExcpetion;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -312,6 +313,27 @@ class UserControllerTest extends UserControllerTestFixture {
                 .content(objectMapper.writeValueAsString(사용자의_모든_정보_수정_dto))
         ).andExpectAll(
                 status().isNotFound(),
+                jsonPath("$.message").exists()
+        );
+    }
+
+
+    @Test
+    void 이미_존재하는_이름으로_사용자_정보_수정시_404를_반환한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(사용자_아이디)).willReturn(true);
+        given(userService.updateById(사용자_아이디, 사용자의_모든_정보_수정_dto))
+                .willThrow(new DuplicateUserNameExcpetion());
+
+        // when & then
+        mockMvc.perform(patch("/users")
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(사용자의_모든_정보_수정_dto))
+        ).andExpectAll(
+                status().isBadRequest(),
                 jsonPath("$.message").exists()
         );
     }


### PR DESCRIPTION
- closed #63 

사용자 이름 수정 시 이미 존재하는 이름인지 예외 처리를 따로 하지 않아 추가해 두었습니다.
다만, 자신의 기존 이름으로 수정하는 경우는 예외 없이 정상 작동하는 것으로 보이도록 했습니다.