### PR TITLE
콕 찌르기 및 알림 전송 추가

### DIFF
--- a/src/docs/asciidoc/docs.adoc
+++ b/src/docs/asciidoc/docs.adoc
@@ -41,3 +41,6 @@ include::friend.adoc[]
 
 == 골
 include::goal.adoc[]
+
+== 콕 찌르기
+include::poke.adoc[]

--- a/src/docs/asciidoc/poke.adoc
+++ b/src/docs/asciidoc/poke.adoc
@@ -1,0 +1,5 @@
+=== 콕 찌르기 요청
+==== 요청
+operation::poke-controller-test/특정_골의_사용자에게_콕_찌르기를_한다[snippets='http-request,request-headers,path-parameters']
+==== 응답
+operation::poke-controller-test/특정_골의_사용자에게_콕_찌르기를_한다[snippets='http-response']

--- a/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
+++ b/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
@@ -55,6 +55,10 @@ public enum ExceptionMessage {
     UPDATE_GOAL_FORBIDDEN("골을 수정할 권한이 없습니다."),
     UPDATE_TEAMS_FORBIDDEN("골 참여자 목록은 비어있을 수 없습니다."),
 
+    // 콕 찌르기
+    SENDER_NOT_IN_GOAL_TEAM("콕 찌르기 요청자가 해당 골의 팀원이 아닙니다."),
+    RECEIVER_NOT_IN_GOAL_TEAM("콕 찌르기 수신자가 해당 골의 팀원이 아닙니다."),
+
     // 관리자 페이지
     INVALID_FRIEND_STATUS("잘못된 친구 상태입니다.");
 

--- a/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
+++ b/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
@@ -54,6 +54,7 @@ public enum ExceptionMessage {
     DELETE_GOAL_FORBIDDEN("골을 삭제할 권한이 없습니다."),
     UPDATE_GOAL_FORBIDDEN("골을 수정할 권한이 없습니다."),
     UPDATE_TEAMS_FORBIDDEN("골 참여자 목록은 비어있을 수 없습니다."),
+    NOT_FOUND_MANAGER("골의 관리자를 찾을 수 없습니다."),
 
     // 콕 찌르기
     SENDER_NOT_IN_GOAL_TEAM("콕 찌르기 요청자가 해당 골의 팀원이 아닙니다."),

--- a/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import com.backend.blooming.goal.application.exception.ForbiddenGoalToPokeExcept
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
+import com.backend.blooming.notification.application.exception.NotFoundGoalManagerException;
 import com.backend.blooming.themecolor.domain.exception.UnsupportedThemeColorException;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import org.springframework.http.HttpHeaders;
@@ -214,6 +215,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         logger.warn(String.format(LOG_MESSAGE_FORMAT, exception.getClass().getSimpleName(), exception.getMessage()));
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                             .body(new ExceptionResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(NotFoundGoalManagerException.class)
+    public ResponseEntity<ExceptionResponse> handleNotFoundGoalManagerException(
+            final NotFoundGoalManagerException exception
+    ) {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, exception.getClass().getSimpleName(), exception.getMessage()));
+
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
                              .body(new ExceptionResponse(exception.getMessage()));
     }
 }

--- a/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import com.backend.blooming.friend.application.exception.FriendAcceptanceForbidd
 import com.backend.blooming.friend.application.exception.FriendRequestNotAllowedException;
 import com.backend.blooming.friend.application.exception.NotFoundFriendRequestException;
 import com.backend.blooming.goal.application.exception.DeleteGoalForbiddenException;
+import com.backend.blooming.goal.application.exception.ForbiddenGoalToPokeException;
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
@@ -203,6 +204,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         logger.warn(String.format(LOG_MESSAGE_FORMAT, exception.getClass().getSimpleName(), exception.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                             .body(new ExceptionResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenGoalToPokeException.class)
+    public ResponseEntity<ExceptionResponse> handleForbiddenGoalToPokeException(
+            final ForbiddenGoalToPokeException exception
+    ) {
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, exception.getClass().getSimpleName(), exception.getMessage()));
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
                              .body(new ExceptionResponse(exception.getMessage()));
     }
 }

--- a/src/main/java/com/backend/blooming/friend/application/FriendService.java
+++ b/src/main/java/com/backend/blooming/friend/application/FriendService.java
@@ -84,6 +84,7 @@ public class FriendService {
         validateRequestedUser(user, friend);
 
         friend.acceptRequest();
+        notificationService.sendAcceptFriendNotification(friend);
     }
 
     private Friend getFriend(final Long requestId) {

--- a/src/main/java/com/backend/blooming/goal/application/GoalService.java
+++ b/src/main/java/com/backend/blooming/goal/application/GoalService.java
@@ -9,6 +9,7 @@ import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
 import com.backend.blooming.goal.domain.Goal;
+import com.backend.blooming.goal.domain.GoalTeam;
 import com.backend.blooming.goal.infrastructure.repository.GoalRepository;
 import com.backend.blooming.notification.application.NotificationService;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
@@ -35,7 +36,7 @@ public class GoalService {
         final List<User> users = getUsers(createGoalDto.teamUserIds());
         final Goal goal = persistGoal(createGoalDto, users);
 
-        notificationService.sendRequestGoalNotification(goal);
+        notificationService.sendRequestGoalNotification(goal, goal.getTeams());
 
         return goal.getId();
     }
@@ -126,7 +127,8 @@ public class GoalService {
         }
         if (updateGoalDto.teamUserIds() != null) {
             final List<User> users = userRepository.findAllByUserIds(updateGoalDto.teamUserIds());
-            goal.updateTeams(users);
+            final List<GoalTeam> updateTeams = goal.updateTeams(users);
+            notificationService.sendRequestGoalNotification(goal, updateTeams);
         }
     }
 

--- a/src/main/java/com/backend/blooming/goal/application/GoalService.java
+++ b/src/main/java/com/backend/blooming/goal/application/GoalService.java
@@ -10,6 +10,7 @@ import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
 import com.backend.blooming.goal.domain.Goal;
 import com.backend.blooming.goal.infrastructure.repository.GoalRepository;
+import com.backend.blooming.notification.application.NotificationService;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
@@ -25,15 +26,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class GoalService {
 
-    private static final int TEAMS_MAXIMUM_LENGTH = 5;
-
     private final GoalRepository goalRepository;
     private final UserRepository userRepository;
     private final FriendRepository friendRepository;
+    private final NotificationService notificationService;
 
     public Long createGoal(final CreateGoalDto createGoalDto) {
         final List<User> users = getUsers(createGoalDto.teamUserIds());
         final Goal goal = persistGoal(createGoalDto, users);
+
+        notificationService.sendRequestGoalNotification(goal);
 
         return goal.getId();
     }

--- a/src/main/java/com/backend/blooming/goal/application/PokeService.java
+++ b/src/main/java/com/backend/blooming/goal/application/PokeService.java
@@ -25,7 +25,7 @@ public class PokeService {
     public void poke(final PokeDto pokeDto) {
         final User sender = getUser(pokeDto.senderId());
         final User receiver = getUser(pokeDto.receiverId());
-        final Goal goal = getGaol(pokeDto.goalId());
+        final Goal goal = getGoal(pokeDto.goalId());
 
         validateGoalTeams(goal, sender, receiver);
 
@@ -37,7 +37,7 @@ public class PokeService {
                              .orElseThrow(NotFoundUserException::new);
     }
 
-    private Goal getGaol(final Long goalId) {
+    private Goal getGoal(final Long goalId) {
         return goalRepository.findByIdWithUserAndDeletedIsFalse(goalId)
                              .orElseThrow(NotFoundGoalException::new);
     }

--- a/src/main/java/com/backend/blooming/goal/application/PokeService.java
+++ b/src/main/java/com/backend/blooming/goal/application/PokeService.java
@@ -1,0 +1,53 @@
+package com.backend.blooming.goal.application;
+
+import com.backend.blooming.goal.application.dto.PokeDto;
+import com.backend.blooming.goal.application.exception.ForbiddenGoalToPokeException;
+import com.backend.blooming.goal.application.exception.NotFoundGoalException;
+import com.backend.blooming.goal.domain.Goal;
+import com.backend.blooming.goal.infrastructure.repository.GoalRepository;
+import com.backend.blooming.notification.application.NotificationService;
+import com.backend.blooming.user.application.exception.NotFoundUserException;
+import com.backend.blooming.user.domain.User;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PokeService {
+
+    private final UserRepository userRepository;
+    private final GoalRepository goalRepository;
+    private final NotificationService notificationService;
+
+    public void poke(final PokeDto pokeDto) {
+        final User sender = getUser(pokeDto.senderId());
+        final User receiver = getUser(pokeDto.receiverId());
+        final Goal goal = getGaol(pokeDto.goalId());
+
+        validateGoalTeams(goal, sender, receiver);
+
+        notificationService.sendPokeNotification(goal, sender, receiver);
+    }
+
+    private User getUser(final Long userId) {
+        return userRepository.findByIdAndDeletedIsFalse(userId)
+                             .orElseThrow(NotFoundUserException::new);
+    }
+
+    private Goal getGaol(final Long goalId) {
+        return goalRepository.findByIdWithUserAndDeletedIsFalse(goalId)
+                             .orElseThrow(NotFoundGoalException::new);
+    }
+
+    private void validateGoalTeams(final Goal goal, final User sender, final User receiver) {
+        if (!goal.isTeam(sender)) {
+            throw new ForbiddenGoalToPokeException.SenderNotInGoalTeam();
+        }
+        if (!goal.isTeam(receiver)) {
+            throw new ForbiddenGoalToPokeException.ReceiverNotInGoalTeam();
+        }
+    }
+}

--- a/src/main/java/com/backend/blooming/goal/application/dto/PokeDto.java
+++ b/src/main/java/com/backend/blooming/goal/application/dto/PokeDto.java
@@ -1,0 +1,4 @@
+package com.backend.blooming.goal.application.dto;
+
+public record PokeDto(Long goalId, Long senderId, Long receiverId) {
+}

--- a/src/main/java/com/backend/blooming/goal/application/dto/PokeDto.java
+++ b/src/main/java/com/backend/blooming/goal/application/dto/PokeDto.java
@@ -1,4 +1,8 @@
 package com.backend.blooming.goal.application.dto;
 
 public record PokeDto(Long goalId, Long senderId, Long receiverId) {
+
+    public static PokeDto of(final Long goalId, final Long senderId, final Long receiverId) {
+        return new PokeDto(goalId, senderId, receiverId);
+    }
 }

--- a/src/main/java/com/backend/blooming/goal/application/dto/ReadAllGoalDto.java
+++ b/src/main/java/com/backend/blooming/goal/application/dto/ReadAllGoalDto.java
@@ -28,7 +28,6 @@ public record ReadAllGoalDto(List<GoalInfoDto> goalInfos) {
         
         public static GoalInfoDto from(final Goal goal) {
             final List<GoalTeamDto> teams = goal.getTeams()
-                                                .getGoalTeams()
                                                 .stream()
                                                 .map(GoalTeamDto::from)
                                                 .toList();

--- a/src/main/java/com/backend/blooming/goal/application/dto/ReadGoalDetailDto.java
+++ b/src/main/java/com/backend/blooming/goal/application/dto/ReadGoalDetailDto.java
@@ -20,7 +20,6 @@ public record ReadGoalDetailDto(
 
     public static ReadGoalDetailDto from(final Goal goal) {
         final List<GoalTeamDto> teams = goal.getTeams()
-                                            .getGoalTeams()
                                             .stream()
                                             .map(GoalTeamDto::from)
                                             .toList();

--- a/src/main/java/com/backend/blooming/goal/application/exception/ForbiddenGoalToPokeException.java
+++ b/src/main/java/com/backend/blooming/goal/application/exception/ForbiddenGoalToPokeException.java
@@ -1,0 +1,25 @@
+package com.backend.blooming.goal.application.exception;
+
+import com.backend.blooming.exception.BloomingException;
+import com.backend.blooming.exception.ExceptionMessage;
+
+public class ForbiddenGoalToPokeException extends BloomingException {
+
+    private ForbiddenGoalToPokeException(final ExceptionMessage exceptionMessage) {
+        super(exceptionMessage);
+    }
+
+    public static class SenderNotInGoalTeam extends ForbiddenGoalToPokeException {
+
+        public SenderNotInGoalTeam() {
+            super(ExceptionMessage.SENDER_NOT_IN_GOAL_TEAM);
+        }
+    }
+
+    public static class ReceiverNotInGoalTeam extends ForbiddenGoalToPokeException {
+
+        public ReceiverNotInGoalTeam() {
+            super(ExceptionMessage.RECEIVER_NOT_IN_GOAL_TEAM);
+        }
+    }
+}

--- a/src/main/java/com/backend/blooming/goal/domain/Goal.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Goal.java
@@ -98,8 +98,8 @@ public class Goal extends BaseTimeEntity {
         this.goalTerm.updateEndDate(endDate);
     }
     
-    public void updateTeams(final List<User> users) {
-        this.teams.update(users, this);
+    public List<GoalTeam> updateTeams(final List<User> users) {
+        return this.teams.update(users, this);
     }
 
     public void updateDeleted(final Long userId) {
@@ -115,5 +115,9 @@ public class Goal extends BaseTimeEntity {
 
     public boolean isTeam(final User user) {
         return teams.isTeam(user);
+    }
+
+    public List<GoalTeam> getTeams() {
+        return teams.getGoalTeams();
     }
 }

--- a/src/main/java/com/backend/blooming/goal/domain/Goal.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Goal.java
@@ -112,4 +112,8 @@ public class Goal extends BaseTimeEntity {
             throw new DeleteGoalForbiddenException();
         }
     }
+
+    public boolean isTeam(final User user) {
+        return teams.isTeam(user);
+    }
 }

--- a/src/main/java/com/backend/blooming/goal/domain/Teams.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Teams.java
@@ -47,7 +47,7 @@ public class Teams {
         }
     }
 
-    public void update(final List<User> users, final Goal goal) {
+    public List<GoalTeam> update(final List<User> users, final Goal goal) {
         validateUsersSize(users);
         final List<User> usersBeforeUpdate = this.goalTeams.stream()
                                                            .map(GoalTeam::getUser)
@@ -57,6 +57,8 @@ public class Teams {
                                                  .map(user -> new GoalTeam(user, goal))
                                                  .toList();
         this.goalTeams.addAll(updatedUsers);
+
+        return updatedUsers;
     }
 
     public boolean isTeam(final User user) {

--- a/src/main/java/com/backend/blooming/goal/domain/Teams.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Teams.java
@@ -58,4 +58,9 @@ public class Teams {
                                                  .toList();
         this.goalTeams.addAll(updatedUsers);
     }
+
+    public boolean isTeam(final User user) {
+        return goalTeams.stream()
+                        .anyMatch(goalTeam -> goalTeam.getUser().equals(user));
+    }
 }

--- a/src/main/java/com/backend/blooming/goal/infrastructure/repository/GoalRepository.java
+++ b/src/main/java/com/backend/blooming/goal/infrastructure/repository/GoalRepository.java
@@ -33,4 +33,13 @@ public interface GoalRepository extends JpaRepository<Goal, Long> {
             ORDER BY g.goalTerm.startDate DESC
             """)
     List<Goal> findAllByUserIdAndFinished(final Long userId, final LocalDate now);
+
+    @Query("""
+            SELECT g
+            FROM Goal g
+            JOIN FETCH g.teams.goalTeams gt
+            JOIN FETCH gt.user gtu
+            WHERE g.id = :goalId AND g.deleted = FALSE
+            """)
+    Optional<Goal> findByIdWithUserAndDeletedIsFalse(final Long goalId);
 }

--- a/src/main/java/com/backend/blooming/goal/presentation/PokeController.java
+++ b/src/main/java/com/backend/blooming/goal/presentation/PokeController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/goals")
 @RequiredArgsConstructor
@@ -19,7 +18,6 @@ public class PokeController {
 
     private final PokeService pokeService;
 
-    // TODO: 2/17/24 API의 URI 상 이 패키지가 적절하다고 생각했는데, 괜찮을까요?
     @PostMapping(value = "/{goalId}/poke/{userId}", headers = "X-API-VERSION=1")
     public ResponseEntity<Void> poke(
             @Authenticated final AuthenticatedUser authenticatedUser,

--- a/src/main/java/com/backend/blooming/goal/presentation/PokeController.java
+++ b/src/main/java/com/backend/blooming/goal/presentation/PokeController.java
@@ -1,0 +1,34 @@
+package com.backend.blooming.goal.presentation;
+
+import com.backend.blooming.authentication.presentation.anotaion.Authenticated;
+import com.backend.blooming.authentication.presentation.argumentresolver.AuthenticatedUser;
+import com.backend.blooming.goal.application.PokeService;
+import com.backend.blooming.goal.application.dto.PokeDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/goals")
+@RequiredArgsConstructor
+public class PokeController {
+
+    private final PokeService pokeService;
+
+    // TODO: 2/17/24 API의 URI 상 이 패키지가 적절하다고 생각했는데, 괜찮을까요?
+    @PostMapping(value = "/{goalId}/poke/{userId}", headers = "X-API-VERSION=1")
+    public ResponseEntity<Void> poke(
+            @Authenticated final AuthenticatedUser authenticatedUser,
+            @PathVariable final Long goalId,
+            @PathVariable final Long userId
+    ) {
+        pokeService.poke(PokeDto.of(goalId, authenticatedUser.userId(), userId));
+
+        return ResponseEntity.noContent()
+                             .build();
+    }
+}

--- a/src/main/java/com/backend/blooming/notification/application/NotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/NotificationService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.backend.blooming.notification.domain.NotificationType.ACCEPT_FRIEND;
 import static com.backend.blooming.notification.domain.NotificationType.POKE;
 import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
 
@@ -71,6 +72,15 @@ public class NotificationService {
 
     public Long sendPokeNotification(final Goal goal, final User sender, final User receiver) {
         final Notification notification = persistNotification(POKE, goal.getName(), sender, receiver);
+        sendNotification(receiver, notification);
+
+        return notification.getId();
+    }
+
+    public Long sendAcceptFriendNotification(final Friend friend) {
+        final User sender = friend.getRequestedUser();
+        final User receiver = friend.getRequestUser();
+        final Notification notification = persistNotification(ACCEPT_FRIEND, null, sender, receiver);
         sendNotification(receiver, notification);
 
         return notification.getId();

--- a/src/main/java/com/backend/blooming/notification/application/NotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/NotificationService.java
@@ -1,18 +1,22 @@
 package com.backend.blooming.notification.application;
 
 import com.backend.blooming.friend.domain.Friend;
+import com.backend.blooming.goal.domain.Goal;
 import com.backend.blooming.notification.application.dto.ReadNotificationsDto;
 import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.notification.domain.NotificationType;
 import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.backend.blooming.notification.domain.NotificationType.POKE;
 import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
 
 @Service
@@ -24,24 +28,6 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
 
-    public Long sendRequestFriendNotification(final Friend friend) {
-        final Notification notification = Notification.builder()
-                                                      .receiver(friend.getRequestedUser())
-                                                      .title(REQUEST_FRIEND.getTitle())
-                                                      .content(REQUEST_FRIEND.getContentByFormat(
-                                                              friend.getRequestUser().getName()
-                                                      ))
-                                                      .type(REQUEST_FRIEND)
-                                                      .requestId(friend.getRequestUser().getId())
-                                                      .build();
-        final Notification savedNotification = notificationRepository.save(notification);
-
-        friend.getRequestedUser().updateNewAlarm(true);
-        fcmNotificationService.sendNotification(notification);
-
-        return savedNotification.getId();
-    }
-
     public ReadNotificationsDto readAllByUserId(final Long userId) {
         final User user = userRepository.findByIdAndDeletedIsFalse(userId)
                                         .orElseThrow(NotFoundUserException::new);
@@ -50,5 +36,43 @@ public class NotificationService {
         user.updateNewAlarm(false);
 
         return ReadNotificationsDto.from(notifications);
+    }
+
+    public Long sendRequestFriendNotification(final Friend friend) {
+        final User sender = friend.getRequestUser();
+        final User receiver = friend.getRequestedUser();
+        final Notification notification = persistNotification(REQUEST_FRIEND, null, sender, receiver);
+        sendNotification(receiver, notification);
+
+        return notification.getId();
+    }
+
+    private Notification persistNotification(
+            final NotificationType notificationType,
+            @Nullable final String titleValue,
+            final User sender,
+            final User receiver
+    ) {
+        final Notification notification = Notification.builder()
+                                                      .receiver(receiver)
+                                                      .title(notificationType.getTitleByFormat(titleValue))
+                                                      .content(notificationType.getContentByFormat(sender.getName()))
+                                                      .type(notificationType)
+                                                      .requestId(sender.getId())
+                                                      .build();
+
+        return notificationRepository.save(notification);
+    }
+
+    private void sendNotification(final User receiver, final Notification notification) {
+        receiver.updateNewAlarm(true);
+        fcmNotificationService.sendNotification(notification);
+    }
+
+    public Long sendPokeNotification(final Goal goal, final User sender, final User receiver) {
+        final Notification notification = persistNotification(POKE, goal.getName(), sender, receiver);
+        sendNotification(receiver, notification);
+
+        return notification.getId();
     }
 }

--- a/src/main/java/com/backend/blooming/notification/application/NotificationService.java
+++ b/src/main/java/com/backend/blooming/notification/application/NotificationService.java
@@ -99,9 +99,9 @@ public class NotificationService {
         return notification.getId();
     }
 
-    public List<Long> sendRequestGoalNotification(final Goal goal) {
+    public List<Long> sendRequestGoalNotification(final Goal goal, final List<GoalTeam> teams) {
         final User sender = getGoalManager(goal);
-        final List<User> receivers = getGoalTeams(goal);
+        final List<User> receivers = getTeamUsers(teams, goal.getManagerId());
         final List<Notification> notifications = persistNotifications(goal, sender, receivers);
         notifications.forEach(this::sendNotification);
 
@@ -111,7 +111,7 @@ public class NotificationService {
     }
 
     private User getGoalManager(final Goal goal) {
-        final List<GoalTeam> teams = goal.getTeams().getGoalTeams();
+        final List<GoalTeam> teams = goal.getTeams();
         final Long managerId = goal.getManagerId();
 
         return teams.stream()
@@ -121,10 +121,7 @@ public class NotificationService {
                     .orElseThrow(NotFoundGoalManagerException::new);
     }
 
-    private List<User> getGoalTeams(final Goal goal) {
-        final List<GoalTeam> teams = goal.getTeams().getGoalTeams();
-        final Long managerId = goal.getManagerId();
-
+    private List<User> getTeamUsers(final List<GoalTeam> teams, final Long managerId) {
         return teams.stream()
                     .map(GoalTeam::getUser)
                     .filter(user -> !user.getId().equals(managerId))

--- a/src/main/java/com/backend/blooming/notification/application/exception/NotFoundGoalManagerException.java
+++ b/src/main/java/com/backend/blooming/notification/application/exception/NotFoundGoalManagerException.java
@@ -1,0 +1,11 @@
+package com.backend.blooming.notification.application.exception;
+
+import com.backend.blooming.exception.BloomingException;
+import com.backend.blooming.exception.ExceptionMessage;
+
+public class NotFoundGoalManagerException extends BloomingException {
+
+    public NotFoundGoalManagerException() {
+        super(ExceptionMessage.NOT_FOUND_MANAGER);
+    }
+}

--- a/src/main/java/com/backend/blooming/notification/domain/NotificationType.java
+++ b/src/main/java/com/backend/blooming/notification/domain/NotificationType.java
@@ -9,6 +9,7 @@ public enum NotificationType {
 
     REQUEST_FRIEND("친구 신청", "%s님이 회원님에게 친구 신청을 요청했습니다."),
     ACCEPT_FRIEND("친구 수락", "%s님이 회원님의 친구 신청을 수락했습니다."),
+    REQUEST_GOAL("골 초대 - %s", "%s님이 회원님을 골에 초대했습니다."),
     POKE("콕 찌르기 - %s", "%s님이 회원님을 콕 찔렀습니다.");
 
     private final String title;

--- a/src/main/java/com/backend/blooming/notification/domain/NotificationType.java
+++ b/src/main/java/com/backend/blooming/notification/domain/NotificationType.java
@@ -8,6 +8,7 @@ import org.springframework.lang.Nullable;
 public enum NotificationType {
 
     REQUEST_FRIEND("친구 신청", "%s님이 회원님에게 친구 신청을 요청했습니다."),
+    ACCEPT_FRIEND("친구 수락", "%s님이 회원님의 친구 신청을 수락했습니다."),
     POKE("콕 찌르기 - %s", "%s님이 회원님을 콕 찔렀습니다.");
 
     private final String title;

--- a/src/main/java/com/backend/blooming/notification/domain/NotificationType.java
+++ b/src/main/java/com/backend/blooming/notification/domain/NotificationType.java
@@ -2,16 +2,20 @@ package com.backend.blooming.notification.domain;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import org.springframework.lang.Nullable;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Getter
 public enum NotificationType {
 
-    REQUEST_FRIEND("친구 신청", "%s님이 회원님에게 친구 신청을 요청했습니다.");
+    REQUEST_FRIEND("친구 신청", "%s님이 회원님에게 친구 신청을 요청했습니다."),
+    POKE("콕 찌르기 - %s", "%s님이 회원님을 콕 찔렀습니다.");
 
     private final String title;
     private final String content;
+
+    public String getTitleByFormat(@Nullable final String value) {
+        return String.format(title, value);
+    }
 
     public String getContentByFormat(final String value) {
         return String.format(content, value);

--- a/src/main/java/com/backend/blooming/stamp/application/StampService.java
+++ b/src/main/java/com/backend/blooming/stamp/application/StampService.java
@@ -51,7 +51,6 @@ public class StampService {
 
     private void validateUserInGoalTeams(final Goal goal, final Long userId) {
         final List<Long> teamUserIds = goal.getTeams()
-                                           .getGoalTeams()
                                            .stream()
                                            .map(goalTeam -> goalTeam.getUser().getId())
                                            .toList();

--- a/src/main/resources/static/docs/authentication.html
+++ b/src/main/resources/static/docs/authentication.html
@@ -669,7 +669,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-26 08:53:29 +0900
+Last updated 2024-01-28 21:29:55 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/docs.html
+++ b/src/main/resources/static/docs/docs.html
@@ -492,6 +492,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_골_수정">골 수정</a></li>
 </ul>
 </li>
+<li><a href="#_콕_찌르기">콕 찌르기</a>
+<ul class="sectlevel2">
+<li><a href="#_콕_찌르기_요청">콕 찌르기 요청</a></li>
+</ul>
+</li>
 </ul>
 </div>
 </div>
@@ -2295,8 +2300,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-02-15",
-  "endDate" : "2024-02-25",
+  "startDate" : "2024-02-18",
+  "endDate" : "2024-02-28",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -2468,8 +2473,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-02-15",
-  "endDate" : "2024-02-25",
+  "startDate" : "2024-02-18",
+  "endDate" : "2024-02-28",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -2495,8 +2500,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-02-15",
-  "endDate" : "2024-02-25",
+  "startDate" : "2024-02-18",
+  "endDate" : "2024-02-28",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -2643,8 +2648,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-02-15",
-    "endDate" : "2024-02-25",
+    "startDate" : "2024-02-18",
+    "endDate" : "2024-02-28",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -2668,8 +2673,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-02-15",
-    "endDate" : "2024-02-25",
+    "startDate" : "2024-02-18",
+    "endDate" : "2024-02-28",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -2799,8 +2804,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-02-15",
-    "endDate" : "2024-02-20",
+    "startDate" : "2024-02-18",
+    "endDate" : "2024-02-23",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -2824,8 +2829,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-02-15",
-    "endDate" : "2024-02-20",
+    "startDate" : "2024-02-18",
+    "endDate" : "2024-02-23",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -2992,7 +2997,7 @@ Authorization: Bearer access_token
 {
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "endDate" : "2024-03-06",
+  "endDate" : "2024-03-09",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -3059,8 +3064,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-02-15",
-  "endDate" : "2024-03-06",
+  "startDate" : "2024-02-18",
+  "endDate" : "2024-03-09",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -3091,8 +3096,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-02-15",
-  "endDate" : "2024-03-06",
+  "startDate" : "2024-02-18",
+  "endDate" : "2024-03-09",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -3193,11 +3198,95 @@ Content-Type: application/json
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_콕_찌르기"><a class="link" href="#_콕_찌르기">콕 찌르기</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_콕_찌르기_요청"><a class="link" href="#_콕_찌르기_요청">콕 찌르기 요청</a></h3>
+<div class="sect3">
+<h4 id="_요청_22"><a class="link" href="#_요청_22">요청</a></h4>
+<div class="sect4">
+<h5 id="_요청_22_http_request"><a class="link" href="#_요청_22_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /goals/1/poke/2 HTTP/1.1
+X-API-VERSION: 1
+Authorization: Bearer access_token
+Content-Type: application/x-www-form-urlencoded</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_요청_22_request_headers"><a class="link" href="#_요청_22_request_headers">Request headers</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>X-API-VERSION</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청 버전</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_요청_22_path_parameters"><a class="link" href="#_요청_22_path_parameters">Path parameters</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 2. /goals/{goalId}/poke/{userId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>goalId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">골 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">콕 찌를 사용자 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_22"><a class="link" href="#_응답_22">응답</a></h4>
+<div class="sect4">
+<h5 id="_응답_22_http_response"><a class="link" href="#_응답_22_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-01 19:10:19 +0900
+Last updated 2024-02-18 03:44:47 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/friend.html
+++ b/src/main/resources/static/docs/friend.html
@@ -1093,7 +1093,7 @@ Authorization: Bearer access_token</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-26 08:53:29 +0900
+Last updated 2024-01-28 21:29:55 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/goal.html
+++ b/src/main/resources/static/docs/goal.html
@@ -456,8 +456,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-02-15",
-  "endDate" : "2024-02-25",
+  "startDate" : "2024-02-18",
+  "endDate" : "2024-02-28",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -629,8 +629,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-02-15",
-  "endDate" : "2024-02-25",
+  "startDate" : "2024-02-18",
+  "endDate" : "2024-02-28",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -656,8 +656,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-02-15",
-  "endDate" : "2024-02-25",
+  "startDate" : "2024-02-18",
+  "endDate" : "2024-02-28",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -804,8 +804,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-02-15",
-    "endDate" : "2024-02-25",
+    "startDate" : "2024-02-18",
+    "endDate" : "2024-02-28",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -829,8 +829,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-02-15",
-    "endDate" : "2024-02-25",
+    "startDate" : "2024-02-18",
+    "endDate" : "2024-02-28",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -960,8 +960,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-02-15",
-    "endDate" : "2024-02-20",
+    "startDate" : "2024-02-18",
+    "endDate" : "2024-02-23",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -985,8 +985,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-02-15",
-    "endDate" : "2024-02-20",
+    "startDate" : "2024-02-18",
+    "endDate" : "2024-02-23",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -1153,7 +1153,7 @@ Authorization: Bearer access_token
 {
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "endDate" : "2024-03-06",
+  "endDate" : "2024-03-09",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -1220,8 +1220,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-02-15",
-  "endDate" : "2024-03-06",
+  "startDate" : "2024-02-18",
+  "endDate" : "2024-03-09",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -1252,8 +1252,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-02-15",
-  "endDate" : "2024-03-06",
+  "startDate" : "2024-02-18",
+  "endDate" : "2024-03-09",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -1356,7 +1356,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-15 16:12:25 +0900
+Last updated 2024-02-17 03:08:35 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/notification.html
+++ b/src/main/resources/static/docs/notification.html
@@ -550,7 +550,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-01 19:10:19 +0900
+Last updated 2024-02-01 20:29:52 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/poke.html
+++ b/src/main/resources/static/docs/poke.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.18">
-<title>전체 테마 색상 목록 조회</title>
+<title>콕 찌르기 요청</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -441,15 +441,22 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="content">
 <div class="sect2">
-<h3 id="_전체_테마_색상_목록_조회">전체 테마 색상 목록 조회</h3>
+<h3 id="_콕_찌르기_요청">콕 찌르기 요청</h3>
 <div class="sect3">
 <h4 id="_요청">요청</h4>
+<div class="sect4">
+<h5 id="_요청_http_request">HTTP request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /theme-colors HTTP/1.1
-X-API-VERSION: 1</code></pre>
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /goals/1/poke/2 HTTP/1.1
+X-API-VERSION: 1
+Authorization: Bearer access_token
+Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
+</div>
+<div class="sect4">
+<h5 id="_요청_request_headers">Request headers</h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -466,65 +473,57 @@ X-API-VERSION: 1</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>X-API-VERSION</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">요청 버전</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
 </tbody>
 </table>
 </div>
-<div class="sect3">
-<h4 id="_응답">응답</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "themeColors" : [ {
-    "name" : "BEIGE",
-    "code" : "#f5f1f0"
-  }, {
-    "name" : "BABY_PINK",
-    "code" : "#f8c8c4"
-  } ]
-}</code></pre>
-</div>
-</div>
+<div class="sect4">
+<h5 id="_요청_path_parameters">Path parameters</h5>
 <table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /goals/{goalId}/poke/{userId}</caption>
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>themeColors.[]</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">테마 색상 목록</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>goalId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">골 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>themeColors.[].name</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">테마 색상 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>themeColors.[].code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">테마 색상 코드</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">콕 찌를 사용자 아이디</p></td>
 </tr>
 </tbody>
 </table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답">응답</h4>
+<div class="sect4">
+<h5 id="_응답_http_response">HTTP response</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-28 21:29:55 +0900
+Last updated 2024-02-18 03:44:22 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/user.html
+++ b/src/main/resources/static/docs/user.html
@@ -823,7 +823,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-26 08:53:29 +0900
+Last updated 2024-01-28 21:29:55 +0900
 </div>
 </div>
 </body>

--- a/src/test/java/com/backend/blooming/authentication/application/AuthenticationServiceTest.java
+++ b/src/test/java/com/backend/blooming/authentication/application/AuthenticationServiceTest.java
@@ -93,7 +93,6 @@ class AuthenticationServiceTest extends AuthenticationServiceTestFixture {
                                                      oauth_타입
                                              )
                                              .get();
-        System.out.println(savedUser);
 
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual.token().accessToken()).isNotEmpty();

--- a/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
+++ b/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
@@ -11,6 +11,8 @@ import com.backend.blooming.friend.infrastructure.repository.FriendRepository;
 import com.backend.blooming.notification.domain.Notification;
 import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
+import com.backend.blooming.user.domain.User;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -38,6 +40,9 @@ class FriendServiceTest extends FriendServiceTestFixture {
     @Autowired
     private NotificationRepository notificationRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @Test
     void 친구를_요청한다() {
         // when
@@ -54,11 +59,13 @@ class FriendServiceTest extends FriendServiceTestFixture {
 
         // then
         final List<Notification> notification = notificationRepository.findAllByReceiverId(아직_친구_요청_전의_사용자_아이디);
+        final User user = userRepository.findById(아직_친구_요청_전의_사용자_아이디).get();
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(notification).hasSize(1);
             softAssertions.assertThat(notification.get(0).getId()).isPositive();
             softAssertions.assertThat(notification.get(0).getReceiver().getId()).isEqualTo(아직_친구_요청_전의_사용자_아이디);
             softAssertions.assertThat(notification.get(0).getRequestId()).isEqualTo(사용자_아이디);
+            softAssertions.assertThat(user.isNewAlarm()).isTrue();
         });
     }
 

--- a/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
+++ b/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
@@ -160,6 +160,23 @@ class FriendServiceTest extends FriendServiceTestFixture {
     }
 
     @Test
+    void 친구_수락시_요청_상대에게_알림이_저장된다() {
+        // when
+        friendService.accept(이미_친구_요청을_받은_사용자_아이디, 친구_요청_아이디);
+
+        // then
+        final List<Notification> notification = notificationRepository.findAllByReceiverId(친구_요청자의_아이디);
+        final User user = userRepository.findById(친구_요청자의_아이디).get();
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(notification).hasSize(1);
+            softAssertions.assertThat(notification.get(0).getId()).isPositive();
+            softAssertions.assertThat(notification.get(0).getReceiver().getId()).isEqualTo(친구_요청자의_아이디);
+            softAssertions.assertThat(notification.get(0).getRequestId()).isEqualTo(이미_친구_요청을_받은_사용자_아이디);
+            softAssertions.assertThat(user.isNewAlarm()).isTrue();
+        });
+    }
+
+    @Test
     void 친구_요청_수락시_해당_요청이_존재하지_않는_경우_예외를_반환한다() {
         // when & then
         assertThatThrownBy(() -> friendService.accept(사용자_아이디, 존재하지_않는_친구_요청_아이디))

--- a/src/test/java/com/backend/blooming/friend/application/FriendServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/friend/application/FriendServiceTestFixture.java
@@ -25,6 +25,7 @@ public class FriendServiceTestFixture {
 
     protected Long 존재하지_않는_사용자_아이디 = 9999L;
     protected Long 사용자_아이디;
+    protected Long 친구_요청자의_아이디;
     protected Long 아직_친구_요청_전의_사용자_아이디;
     protected Long 이미_친구_요청을_받은_사용자_아이디;
     protected Long 친구_요청_아이디;
@@ -111,6 +112,7 @@ public class FriendServiceTestFixture {
         ));
 
         사용자_아이디 = 사용자.getId();
+        친구_요청자의_아이디 = 사용자.getId();
         아직_친구_요청_전의_사용자_아이디 = 친구_요청할_사용자.getId();
         이미_친구_요청을_받은_사용자_아이디 = 이미_친구_요청을_받은_사용자.getId();
         친구_요청을_받지_않은_사용자_아이디 = 아직_친구_요청_전의_사용자_아이디;

--- a/src/test/java/com/backend/blooming/goal/application/PokeServiceTest.java
+++ b/src/test/java/com/backend/blooming/goal/application/PokeServiceTest.java
@@ -1,0 +1,83 @@
+package com.backend.blooming.goal.application;
+
+import com.backend.blooming.configuration.IsolateDatabase;
+import com.backend.blooming.goal.application.exception.ForbiddenGoalToPokeException;
+import com.backend.blooming.goal.application.exception.NotFoundGoalException;
+import com.backend.blooming.notification.domain.Notification;
+import com.backend.blooming.notification.domain.NotificationType;
+import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
+import com.backend.blooming.user.application.exception.NotFoundUserException;
+import com.backend.blooming.user.domain.User;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IsolateDatabase
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class PokeServiceTest extends PokeServiceTestFixture {
+
+    @Autowired
+    private PokeService pokeService;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void 특정_골의_사용자에게_콕_찌를_수_있다() {
+        // when
+        pokeService.poke(콕_찌르기_요청_dto);
+
+        // then
+        final List<Notification> notifications = notificationRepository.findAllByReceiverId(콕_찌르기를_받은_사용자_아이디);
+        final Notification pokeNotification = notifications.get(0);
+        final User user = userRepository.findById(콕_찌르기를_받은_사용자_아이디).get();
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(notifications).isNotEmpty();
+            softAssertions.assertThat(pokeNotification.getRequestId()).isEqualTo(콕_찌르기를_요청한_사용자_아이디);
+            softAssertions.assertThat(pokeNotification.getReceiver().getId()).isEqualTo(콕_찌르기를_받은_사용자_아이디);
+            softAssertions.assertThat(pokeNotification.getType()).isEqualTo(NotificationType.POKE);
+            softAssertions.assertThat(user.isNewAlarm()).isTrue();
+        });
+    }
+
+    @Test
+    void 특정_골의_사용자에게_콕찌를_때_존재하지_않는_골이라면_예외를_반환한다() {
+        assertThatThrownBy(() -> pokeService.poke(존재하지_않는_골에_대한_콕_찌르기_요청_dto))
+                .isInstanceOf(NotFoundGoalException.class);
+    }
+
+    @Test
+    void 특정_골의_사용자에게_콕찌를_때_요청자가_존재하지_않는다면_예외를_반환한다() {
+        assertThatThrownBy(() -> pokeService.poke(존재하지_않는_사용자가_콕_찌르기_요청_dto))
+                .isInstanceOf(NotFoundUserException.class);
+    }
+
+    @Test
+    void 특정_골의_사용자에게_콕찌를_때_존재하지_않는_사용자에게_요청하면_예외를_반환한다() {
+        assertThatThrownBy(() -> pokeService.poke(존재하지_않는_사용자에게_콕_찌르기_요청_dto))
+                .isInstanceOf(NotFoundUserException.class);
+    }
+
+    @Test
+    void 특정_골의_포함되어_있지_않는_사용자가_콕찌르는_경우_예외를_반환한다() {
+        assertThatThrownBy(() -> pokeService.poke(골에_포함되어_있지_않는_사용자가_콕_찌르기_요청_dto))
+                .isInstanceOf(ForbiddenGoalToPokeException.SenderNotInGoalTeam.class);
+    }
+
+    @Test
+    void 특정_골의_포함되어_있지_않는_사용자에게_콕찌르는_경우_예외를_반환한다() {
+        assertThatThrownBy(() -> pokeService.poke(골에_포함되어_있지_않는_사용자에게_콕_찌르기_요청_dto))
+                .isInstanceOf(ForbiddenGoalToPokeException.ReceiverNotInGoalTeam.class);
+    }
+}

--- a/src/test/java/com/backend/blooming/goal/application/PokeServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/goal/application/PokeServiceTestFixture.java
@@ -1,0 +1,82 @@
+package com.backend.blooming.goal.application;
+
+import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
+import com.backend.blooming.goal.application.dto.PokeDto;
+import com.backend.blooming.goal.domain.Goal;
+import com.backend.blooming.goal.infrastructure.repository.GoalRepository;
+import com.backend.blooming.user.domain.Email;
+import com.backend.blooming.user.domain.Name;
+import com.backend.blooming.user.domain.User;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class PokeServiceTestFixture {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GoalRepository goalRepository;
+
+    protected PokeDto 콕_찌르기_요청_dto;
+    protected Long 콕_찌르기를_받은_사용자_아이디;
+    protected Long 콕_찌르기를_요청한_사용자_아이디;
+    protected PokeDto 존재하지_않는_골에_대한_콕_찌르기_요청_dto;
+    protected PokeDto 존재하지_않는_사용자가_콕_찌르기_요청_dto;
+    protected PokeDto 존재하지_않는_사용자에게_콕_찌르기_요청_dto;
+    protected PokeDto 골에_포함되어_있지_않는_사용자가_콕_찌르기_요청_dto;
+    protected PokeDto 골에_포함되어_있지_않는_사용자에게_콕_찌르기_요청_dto;
+
+    @BeforeEach
+    void setUpFixture() {
+        final User 콕_찌르기_요청자 = User.builder()
+                                   .oAuthId("12345")
+                                   .oAuthType(OAuthType.KAKAO)
+                                   .name(new Name("사용자1"))
+                                   .email(new Email("test1@email.com"))
+                                   .build();
+        final User 콕_찌르기_수신자 = User.builder()
+                                   .oAuthId("12346")
+                                   .oAuthType(OAuthType.KAKAO)
+                                   .name(new Name("사용자2"))
+                                   .email(new Email("test2@email.com"))
+                                   .build();
+        final User 팀원이_아닌_사용자 = User.builder()
+                                    .oAuthId("12347")
+                                    .oAuthType(OAuthType.KAKAO)
+                                    .name(new Name("사용자3"))
+                                    .email(new Email("test3@email.com"))
+                                    .build();
+        userRepository.saveAll(List.of(콕_찌르기_요청자, 콕_찌르기_수신자, 팀원이_아닌_사용자));
+
+        콕_찌르기를_요청한_사용자_아이디 = 콕_찌르기_요청자.getId();
+        콕_찌르기를_받은_사용자_아이디 = 콕_찌르기_수신자.getId();
+        final List<User> 골_참여_사용자_목록 = List.of(콕_찌르기_요청자, 콕_찌르기_수신자);
+
+        final Goal 골 = Goal.builder()
+                           .name("골 제목")
+                           .memo("골 메모")
+                           .startDate(LocalDate.now())
+                           .endDate(LocalDate.now().plusDays(20))
+                           .managerId(콕_찌르기를_요청한_사용자_아이디)
+                           .users(골_참여_사용자_목록)
+                           .build();
+        goalRepository.save(골);
+        final Long 골_아이디 = 골.getId();
+
+        final Long 존재하지_않는_골_아이디 = 999L;
+        final Long 존재하지_않는_사용자_아이디 = 999L;
+        final Long 팀원이_아닌_사용자_아이디 = 팀원이_아닌_사용자.getId();
+        콕_찌르기_요청_dto = new PokeDto(골_아이디, 콕_찌르기를_요청한_사용자_아이디, 콕_찌르기를_받은_사용자_아이디);
+        존재하지_않는_골에_대한_콕_찌르기_요청_dto = new PokeDto(존재하지_않는_골_아이디, 콕_찌르기를_요청한_사용자_아이디, 콕_찌르기를_받은_사용자_아이디);
+        존재하지_않는_사용자가_콕_찌르기_요청_dto = new PokeDto(골_아이디, 존재하지_않는_사용자_아이디, 콕_찌르기를_받은_사용자_아이디);
+        존재하지_않는_사용자에게_콕_찌르기_요청_dto = new PokeDto(골_아이디, 콕_찌르기를_요청한_사용자_아이디, 존재하지_않는_사용자_아이디);
+        골에_포함되어_있지_않는_사용자가_콕_찌르기_요청_dto = new PokeDto(골_아이디, 팀원이_아닌_사용자_아이디, 콕_찌르기를_받은_사용자_아이디);
+        골에_포함되어_있지_않는_사용자에게_콕_찌르기_요청_dto = new PokeDto(골_아이디, 콕_찌르기를_요청한_사용자_아이디, 팀원이_아닌_사용자_아이디);
+    }
+}

--- a/src/test/java/com/backend/blooming/goal/domain/GoalTest.java
+++ b/src/test/java/com/backend/blooming/goal/domain/GoalTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class GoalTest extends GoalTestFixture {
-    
+
     @Test
     void 골_메모를_빈_값으로_받은_경우_비어있는_값으로_저장한다() {
         // when
@@ -30,11 +30,11 @@ class GoalTest extends GoalTestFixture {
                               .managerId(골_관리자_아이디)
                               .users(골_참여자_목록)
                               .build();
-        
+
         // then
         assertThat(goal.getMemo()).isEmpty();
     }
-    
+
     @Test
     void 골_생성시_골_팀을_생성한다() {
         // when
@@ -46,11 +46,11 @@ class GoalTest extends GoalTestFixture {
                               .managerId(골_관리자_아이디)
                               .users(골_참여자_목록)
                               .build();
-        
+
         // then
-        assertThat(goal.getTeams().getGoalTeams()).hasSize(2);
+        assertThat(goal.getTeams()).hasSize(2);
     }
-    
+
     @Test
     void 골_참여자_목록이_5명_초과인_경우_예외를_발생한다() {
         // when & then
@@ -64,116 +64,119 @@ class GoalTest extends GoalTestFixture {
                                      .build())
                 .isInstanceOf(InvalidGoalException.InvalidInvalidUsersSize.class);
     }
-    
+
     @Test
     void 골_제목을_수정한다() {
         // given
         final Goal goal = 유효한_골;
-        
+
         // when
         goal.updateName("골 제목 테스트");
-        
+
         // then
         assertThat(goal.getName()).isEqualTo("골 제목 테스트");
     }
-    
+
     @Test
     void 요청한_골_제목_글자수가_50자_이상이거나_빈_값인_경우_예외를_발생한다() {
         // given
         final Goal goal = 유효한_골;
-        
+
         // when & then
         assertThatThrownBy(() -> goal.updateName("testtesttesttesttesttesttesttesttesttesttesttesttest"))
                 .isInstanceOf(InvalidGoalException.InvalidInvalidGoalName.class);
         assertThatThrownBy(() -> goal.updateName(""))
                 .isInstanceOf(InvalidGoalException.InvalidInvalidGoalName.class);
     }
-    
+
     @Test
     void 골_메모를_수정한다() {
         // given
         final Goal goal = 유효한_골;
-        
+
         // when
         goal.updateMemo("골 메모 테스트");
-        
+
         // then
         assertThat(goal.getMemo()).isEqualTo("골 메모 테스트");
     }
-    
+
     @ParameterizedTest
     @NullAndEmptySource
     void 요청한_골_메모가_빈_값인_경우_비어있는_값으로_저장한다(final String emptyMemo) {
         // given
         final Goal goal = 유효한_골;
-        
+
         // when
         goal.updateMemo(emptyMemo);
-        
+
         // then
         assertThat(goal.getMemo()).isEmpty();
     }
-    
+
     @Test
     void 골_종료날짜를_수정한다() {
         // given
         final Goal goal = 유효한_골;
-        
+
         // when
         goal.updateEndDate(LocalDate.now().plusDays(20));
-        
+
         // then
         assertThat(goal.getGoalTerm().getEndDate()).isEqualTo(LocalDate.now().plusDays(20));
     }
-    
+
     @Test
     void 골_종료날짜가_현재_종료날짜보다_이전일_경우_예외를_발생한다() {
         // given
         final Goal goal = 유효한_골;
-        
+
         // when & then
         assertThatThrownBy(() -> goal.updateEndDate(수정_요청한_골_종료일))
                 .isInstanceOf(InvalidGoalException.InvalidInvalidUpdateEndDate.class);
     }
-    
+
     @Test
     void 골_팀_목록을_수정한다() {
         // given
         final Goal goal = 유효한_골;
-        
+
         // when
-        goal.updateTeams(수정_요청한_골_참여자_목록);
-        
+        final List<GoalTeam> actual = goal.updateTeams(수정_요청한_골_참여자_목록);
+
         // then
         assertSoftly(softAssertions -> {
-            final List<GoalTeam> teams = goal.getTeams().getGoalTeams();
-            assertThat(teams).hasSize(3);
-            assertThat(teams.get(0).getUser().getId()).isEqualTo(기존_골_참여자.getId());
-            assertThat(teams.get(0).getUser().getName()).isEqualTo(기존_골_참여자.getName());
-            assertThat(teams.get(1).getUser().getId()).isEqualTo(기존_골_참여자2.getId());
-            assertThat(teams.get(1).getUser().getName()).isEqualTo(기존_골_참여자2.getName());
-            assertThat(teams.get(2).getUser().getId()).isEqualTo(추가된_골_참여_사용자.getId());
-            assertThat(teams.get(2).getUser().getName()).isEqualTo(추가된_골_참여_사용자.getName());
+            softAssertions.assertThat(actual).hasSize(1);
+            softAssertions.assertThat(actual.get(0).getUser().getId()).isEqualTo(추가된_골_참여_사용자.getId());
+            softAssertions.assertThat(actual.get(0).getUser().getName()).isEqualTo(추가된_골_참여_사용자.getName());
+            final List<GoalTeam> teams = goal.getTeams();
+            softAssertions.assertThat(teams).hasSize(3);
+            softAssertions.assertThat(teams.get(0).getUser().getId()).isEqualTo(기존_골_참여자.getId());
+            softAssertions.assertThat(teams.get(0).getUser().getName()).isEqualTo(기존_골_참여자.getName());
+            softAssertions.assertThat(teams.get(1).getUser().getId()).isEqualTo(기존_골_참여자2.getId());
+            softAssertions.assertThat(teams.get(1).getUser().getName()).isEqualTo(기존_골_참여자2.getName());
+            softAssertions.assertThat(teams.get(2).getUser().getId()).isEqualTo(추가된_골_참여_사용자.getId());
+            softAssertions.assertThat(teams.get(2).getUser().getName()).isEqualTo(추가된_골_참여_사용자.getName());
         });
     }
-    
+
     @Test
     void 골을_삭제한다() {
         // given
         final Goal goal = 유효한_골;
-        
+
         // when
         goal.updateDeleted(골_관리자_아이디);
-        
+
         // then
         assertThat(goal.isDeleted()).isTrue();
     }
-    
+
     @Test
     void 골_삭제_요청한_사용자의_아이디가_골_관리자_아이디와_다른_경우_예외를_발생한다() {
         // given
         final Goal goal = 유효한_골;
-        
+
         // when & then
         assertThatThrownBy(() -> goal.updateDeleted(골_관리자가_아닌_사용자_아이디))
                 .isInstanceOf(DeleteGoalForbiddenException.class);

--- a/src/test/java/com/backend/blooming/goal/domain/TeamsTest.java
+++ b/src/test/java/com/backend/blooming/goal/domain/TeamsTest.java
@@ -14,16 +14,16 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class TeamsTest extends TeamsTestFixture {
-    
+
     @Test
     void 골_팀_목록을_생성한다() {
         // when
         final Teams teams = Teams.create(골_참여_사용자_목록, 유효한_골);
-        
+
         // then
         assertThat(teams.getGoalTeams()).hasSize(2);
     }
-    
+
     @Test
     void 골_팀_목록_생성시_참여자_목록_크기가_5보다_큰_경우_예외를_발생한다() {
         // when & then
@@ -37,26 +37,29 @@ class TeamsTest extends TeamsTestFixture {
         final Teams teams = Teams.create(골_참여_사용자_목록, 유효한_골);
 
         // when
-        teams.update(수정할_골_참여_사용자_목록, 유효한_골);
+        final List<GoalTeam> actual = teams.update(수정할_골_참여_사용자_목록, 유효한_골);
 
         // then
         assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(1);
+            softAssertions.assertThat(actual.get(0).getUser().getId()).isEqualTo(추가된_골_참여자.getId());
+            softAssertions.assertThat(actual.get(0).getUser().getName()).isEqualTo(추가된_골_참여자.getName());
             final List<GoalTeam> result = teams.getGoalTeams();
             softAssertions.assertThat(result).hasSize(3);
-            assertThat(result.get(0).getUser().getId()).isEqualTo(골_참여자.getId());
-            assertThat(result.get(0).getUser().getName()).isEqualTo(골_참여자.getName());
-            assertThat(result.get(1).getUser().getId()).isEqualTo(골_참여자2.getId());
-            assertThat(result.get(1).getUser().getName()).isEqualTo(골_참여자2.getName());
-            assertThat(result.get(2).getUser().getId()).isEqualTo(추가된_골_참여자.getId());
-            assertThat(result.get(2).getUser().getName()).isEqualTo(추가된_골_참여자.getName());
+            softAssertions.assertThat(result.get(0).getUser().getId()).isEqualTo(골_참여자.getId());
+            softAssertions.assertThat(result.get(0).getUser().getName()).isEqualTo(골_참여자.getName());
+            softAssertions.assertThat(result.get(1).getUser().getId()).isEqualTo(골_참여자2.getId());
+            softAssertions.assertThat(result.get(1).getUser().getName()).isEqualTo(골_참여자2.getName());
+            softAssertions.assertThat(result.get(2).getUser().getId()).isEqualTo(추가된_골_참여자.getId());
+            softAssertions.assertThat(result.get(2).getUser().getName()).isEqualTo(추가된_골_참여자.getName());
         });
     }
-    
+
     @Test
     void 골_팀_목록_수정시_참여자_목록_크기가_5보다_큰_경우_예외를_발생한다() {
         // given
         final Teams teams = Teams.create(골_참여_사용자_목록, 유효한_골);
-        
+
         // when & then
         assertThatThrownBy(() -> teams.update(크기가_5보다_큰_골_참여_사용자_목록, 유효한_골))
                 .isInstanceOf(InvalidGoalException.InvalidInvalidUsersSize.class);

--- a/src/test/java/com/backend/blooming/goal/domain/TeamsTest.java
+++ b/src/test/java/com/backend/blooming/goal/domain/TeamsTest.java
@@ -61,4 +61,28 @@ class TeamsTest extends TeamsTestFixture {
         assertThatThrownBy(() -> teams.update(크기가_5보다_큰_골_참여_사용자_목록, 유효한_골))
                 .isInstanceOf(InvalidGoalException.InvalidInvalidUsersSize.class);
     }
+
+    @Test
+    void 골_팀_목록에_포함된_사용자라면_참을_반환한다() {
+        // given
+        final Teams teams = Teams.create(골_참여_사용자_목록, 유효한_골);
+
+        // when
+        final boolean actual = teams.isTeam(골_참여자);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 골_팀_목록에_포함된_사용자가_아니라면_거짓을_반환한다() {
+        // given
+        final Teams teams = Teams.create(골_참여_사용자_목록, 유효한_골);
+
+        // when
+        final boolean actual = teams.isTeam(팀원이_아닌_사용자);
+
+        // then
+        assertThat(actual).isFalse();
+    }
 }

--- a/src/test/java/com/backend/blooming/goal/domain/TeamsTestFixture.java
+++ b/src/test/java/com/backend/blooming/goal/domain/TeamsTestFixture.java
@@ -44,6 +44,7 @@ public class TeamsTestFixture {
                               .color(ThemeColor.INDIGO)
                               .statusMessage("상태메시지3")
                               .build();
+    protected User 팀원이_아닌_사용자 = 추가된_골_참여자;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/backend/blooming/goal/infrastructure/repository/GoalRepositoryTest.java
+++ b/src/test/java/com/backend/blooming/goal/infrastructure/repository/GoalRepositoryTest.java
@@ -4,7 +4,6 @@ import com.backend.blooming.configuration.JpaConfiguration;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.domain.Goal;
 import com.backend.blooming.goal.domain.GoalTeam;
-import com.backend.blooming.goal.domain.GoalTerm;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,6 @@ import org.springframework.context.annotation.Import;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -36,7 +34,7 @@ class GoalRepositoryTest extends GoalRepositoryTestFixture {
 
         // then
         assertThat(result).usingRecursiveComparison().isEqualTo(유효한_골);
-        assertThat(result.getTeams().getGoalTeams()).hasSize(2);
+        assertThat(result.getTeams()).hasSize(2);
     }
 
     @Test
@@ -83,7 +81,7 @@ class GoalRepositoryTest extends GoalRepositoryTestFixture {
 
         // then
         assertSoftly(softAssertions -> {
-            final List<GoalTeam> goalTeams = result.getTeams().getGoalTeams();
+            final List<GoalTeam> goalTeams = result.getTeams();
             softAssertions.assertThat(result).usingRecursiveComparison().isEqualTo(유효한_골);
             softAssertions.assertThat(goalTeams).hasSize(2);
             softAssertions.assertThat(goalTeams.get(0).getUser().getId()).isEqualTo(골_관리자_사용자.getId());

--- a/src/test/java/com/backend/blooming/goal/infrastructure/repository/GoalRepositoryTestFixture.java
+++ b/src/test/java/com/backend/blooming/goal/infrastructure/repository/GoalRepositoryTestFixture.java
@@ -76,14 +76,14 @@ public class GoalRepositoryTestFixture {
                         .build();
         이미_종료된_골 = Goal.builder()
                        .name("이미 종료된 골1")
-                       .memo("이미 종료된 골2")
+                       .memo("이미 종료된 골1")
                        .startDate(LocalDate.now())
                        .endDate(LocalDate.now().plusDays(테스트를_위한_시스템_현재_시간_설정값 - 1L))
                        .managerId(골_관리자_사용자.getId())
                        .users(골에_참여한_사용자_목록)
                        .build();
         이미_종료된_골2 = Goal.builder()
-                        .name("이미 종료된 골1")
+                        .name("이미 종료된 골2")
                         .memo("이미 종료된 골2")
                         .startDate(LocalDate.now())
                         .endDate(LocalDate.now().plusDays(테스트를_위한_시스템_현재_시간_설정값 - 1L))

--- a/src/test/java/com/backend/blooming/goal/presentation/PokeControllerTest.java
+++ b/src/test/java/com/backend/blooming/goal/presentation/PokeControllerTest.java
@@ -1,0 +1,168 @@
+package com.backend.blooming.goal.presentation;
+
+import com.backend.blooming.authentication.infrastructure.jwt.TokenProvider;
+import com.backend.blooming.authentication.presentation.argumentresolver.AuthenticatedThreadLocal;
+import com.backend.blooming.common.RestDocsConfiguration;
+import com.backend.blooming.goal.application.PokeService;
+import com.backend.blooming.goal.application.exception.ForbiddenGoalToPokeException;
+import com.backend.blooming.goal.application.exception.NotFoundGoalException;
+import com.backend.blooming.user.application.exception.NotFoundUserException;
+import com.backend.blooming.user.infrastructure.repository.UserRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PokeController.class)
+@AutoConfigureRestDocs
+@Import({RestDocsConfiguration.class, AuthenticatedThreadLocal.class})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class PokeControllerTest extends PokeControllerTestFixture {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PokeService pokeService;
+
+    @Autowired
+    private RestDocumentationResultHandler restDocs;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Test
+    void 특정_골의_사용자에게_콕_찌르기를_한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
+        willDoNothing().given(pokeService).poke(콕_찌르기_요청_dto);
+
+        // when & then
+        mockMvc.perform(post("/goals/{goalId}/poke/{userId}", 유효한_골_아이디, 콕_찌르기_수신자)
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+        ).andExpectAll(
+                status().isNoContent()
+        ).andDo(print()).andDo(restDocs.document(
+                requestHeaders(
+                        headerWithName("X-API-VERSION").description("요청 버전"),
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                pathParameters(
+                        parameterWithName("goalId").description("골 아이디"),
+                        parameterWithName("userId").description("콕 찌를 사용자 아이디")
+                )
+        ));
+    }
+
+    @Test
+    void 존재하지_않는_골에_콕_찌르기를_요청했을_때_404_예외를_반환한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
+        willThrow(new NotFoundGoalException()).given(pokeService).poke(존재하지_않은_골에_콕_찌르기_요청_dto);
+
+        // when & then
+        mockMvc.perform(post("/goals/{goalId}/poke/{userId}", 존재하지_않는_골_아이디, 콕_찌르기_수신자)
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+        ).andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.message").exists()
+        ).andDo(print());
+    }
+
+    @Test
+    void 존재하지_않는_사용자가_콕_찌르기를_요청했을_때_404_예외를_반환한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(존재하지_않는_사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(존재하지_않는_사용자_토큰_정보.userId())).willReturn(true);
+        willThrow(new NotFoundUserException()).given(pokeService).poke(존재하지_않은_사용자가_콕_찌르기_요청_dto);
+
+        // when & then
+        mockMvc.perform(post("/goals/{goalId}/poke/{userId}", 유효한_골_아이디, 콕_찌르기_수신자)
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+        ).andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.message").exists()
+        ).andDo(print());
+    }
+
+    @Test
+    void 존재하지_않는_사용자에게_콕_찌르기를_요청했을_때_404_예외를_반환한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
+        willThrow(new NotFoundUserException()).given(pokeService).poke(존재하지_않은_사용자에게_콕_찌르기_요청_dto);
+
+        // when & then
+        mockMvc.perform(post("/goals/{goalId}/poke/{userId}", 유효한_골_아이디, 존재하지_않는_사용자_아이디)
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+        ).andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.message").exists()
+        ).andDo(print());
+    }
+
+    @Test
+    void 팀원이_아닌_사용자가_콕_찌르기를_요청했을_때_403_예외를_반환한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(팀원이_아닌_사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(팀원이_아닌_사용자_토큰_정보.userId())).willReturn(true);
+        willThrow(new ForbiddenGoalToPokeException.SenderNotInGoalTeam()).given(pokeService)
+                                                                         .poke(팀원이_아닌_사용자가_콕_찌르기_요청_dto);
+
+        // when & then
+        mockMvc.perform(post("/goals/{goalId}/poke/{userId}", 유효한_골_아이디, 콕_찌르기_수신자)
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+        ).andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.message").exists()
+        ).andDo(print());
+    }
+
+    @Test
+    void 팀원이_아닌_사용자에게_콕_찌르기를_요청했을_때_403_예외를_반환한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
+        willThrow(new ForbiddenGoalToPokeException.ReceiverNotInGoalTeam()).given(pokeService)
+                                                                           .poke(팀원이_아닌_사용자에게_콕_찌르기_요청_dto);
+
+        // when & then
+        mockMvc.perform(post("/goals/{goalId}/poke/{userId}", 유효한_골_아이디, 팀원이_아닌_사용자_아이디)
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+        ).andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.message").exists()
+        ).andDo(print());
+    }
+}

--- a/src/test/java/com/backend/blooming/goal/presentation/PokeControllerTestFixture.java
+++ b/src/test/java/com/backend/blooming/goal/presentation/PokeControllerTestFixture.java
@@ -1,0 +1,27 @@
+package com.backend.blooming.goal.presentation;
+
+import com.backend.blooming.authentication.infrastructure.jwt.TokenType;
+import com.backend.blooming.authentication.infrastructure.jwt.dto.AuthClaims;
+import com.backend.blooming.goal.application.dto.PokeDto;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class PokeControllerTestFixture {
+
+    protected TokenType 액세스_토큰_타입 = TokenType.ACCESS;
+    protected String 액세스_토큰 = "Bearer access_token";
+    protected Long 유효한_골_아이디 = 1L;
+    protected Long 콕_찌르기_요청자 = 1L;
+    protected AuthClaims 사용자_토큰_정보 = new AuthClaims(콕_찌르기_요청자);
+    protected Long 콕_찌르기_수신자 = 2L;
+    protected Long 존재하지_않는_골_아이디 = 999L;
+    protected Long 존재하지_않는_사용자_아이디 = 999L;
+    protected AuthClaims 존재하지_않는_사용자_토큰_정보 = new AuthClaims(존재하지_않는_사용자_아이디);
+    protected Long 팀원이_아닌_사용자_아이디 = 3L;
+    protected AuthClaims 팀원이_아닌_사용자_토큰_정보 = new AuthClaims(팀원이_아닌_사용자_아이디);
+    protected PokeDto 콕_찌르기_요청_dto = new PokeDto(유효한_골_아이디, 콕_찌르기_요청자, 콕_찌르기_수신자);
+    protected PokeDto 존재하지_않은_골에_콕_찌르기_요청_dto = new PokeDto(존재하지_않는_골_아이디, 콕_찌르기_요청자, 콕_찌르기_수신자);
+    protected PokeDto 존재하지_않은_사용자가_콕_찌르기_요청_dto = new PokeDto(유효한_골_아이디, 존재하지_않는_사용자_아이디, 콕_찌르기_수신자);
+    protected PokeDto 존재하지_않은_사용자에게_콕_찌르기_요청_dto = new PokeDto(유효한_골_아이디, 콕_찌르기_요청자, 존재하지_않는_사용자_아이디);
+    protected PokeDto 팀원이_아닌_사용자가_콕_찌르기_요청_dto = new PokeDto(유효한_골_아이디, 팀원이_아닌_사용자_아이디, 콕_찌르기_수신자);
+    protected PokeDto 팀원이_아닌_사용자에게_콕_찌르기_요청_dto = new PokeDto(유효한_골_아이디, 콕_찌르기_요청자, 팀원이_아닌_사용자_아이디);
+}

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
+import static com.backend.blooming.notification.domain.NotificationType.ACCEPT_FRIEND;
 import static com.backend.blooming.notification.domain.NotificationType.POKE;
 import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -60,7 +61,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
     @Test
     void 친구_요청에_대한_알림을_저장한다() {
         // when
-        final Long actual = notificationService.sendRequestFriendNotification(보낸_친구_요청);
+        final Long actual = notificationService.sendRequestFriendNotification(친구_요청에_대한_친구);
 
         // then
         final Notification notification = notificationRepository.findById(actual).get();
@@ -72,6 +73,24 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
             softAssertions.assertThat(notification.getType()).isEqualTo(REQUEST_FRIEND);
             softAssertions.assertThat(notification.getRequestId()).isEqualTo(친구_요청을_보낸_사용자.getId());
             softAssertions.assertThat(친구_요청을_받은_사용자.isNewAlarm()).isTrue();
+        });
+    }
+
+    @Test
+    void 친구_수락에_대한_알림을_저장한다() {
+        // when
+        final Long actual = notificationService.sendAcceptFriendNotification(친구_수락에_대한_친구);
+
+        // then
+        final Notification notification = notificationRepository.findById(actual).get();
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).isPositive();
+            softAssertions.assertThat(notification.getReceiver().getId()).isEqualTo(친구_요청을_보낸_사용자.getId());
+            softAssertions.assertThat(notification.getTitle()).isEqualTo(ACCEPT_FRIEND.getTitleByFormat(null));
+            softAssertions.assertThat(notification.getContent()).contains(친구_요청을_수락한_사용자.getName());
+            softAssertions.assertThat(notification.getType()).isEqualTo(ACCEPT_FRIEND);
+            softAssertions.assertThat(notification.getRequestId()).isEqualTo(친구_요청을_수락한_사용자.getId());
+            softAssertions.assertThat(친구_요청을_보낸_사용자.isNewAlarm()).isTrue();
         });
     }
 

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
@@ -117,7 +117,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
     @Test
     void 골_초대_요청에_대한_알림을_저장한다() {
         // when
-        final List<Long> actuals = notificationService.sendRequestGoalNotification(골);
+        final List<Long> actuals = notificationService.sendRequestGoalNotification(골, 골.getTeams());
 
         // then
         actuals.forEach(actual -> {
@@ -140,7 +140,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
     @Test
     void 골_초대_요청시_팀원에_골_관리자가_없다면_예외를_발생시킨다() {
         // when & then
-        assertThatThrownBy(() -> notificationService.sendRequestGoalNotification(팀원에_관리자가_없는_골))
+        assertThatThrownBy(() -> notificationService.sendRequestGoalNotification(팀원에_관리자가_없는_골, 팀원에_관리자가_없는_골.getTeams()))
                 .isInstanceOf(NotFoundGoalManagerException.class);
     }
 }

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
@@ -3,9 +3,9 @@ package com.backend.blooming.notification.application;
 import com.backend.blooming.configuration.IsolateDatabase;
 import com.backend.blooming.notification.application.dto.ReadNotificationsDto;
 import com.backend.blooming.notification.domain.Notification;
-import com.backend.blooming.notification.domain.NotificationType;
 import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
+import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -15,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
+import static com.backend.blooming.notification.domain.NotificationType.POKE;
+import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @IsolateDatabase
@@ -32,6 +34,30 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
     private UserRepository userRepository;
 
     @Test
+    void 특정_사용자의_전체_알림_목록을_조회한다() {
+        // when
+        final ReadNotificationsDto actual = notificationService.readAllByUserId(알림이_있는_사용자.getId());
+
+        // then
+        final User user = userRepository.findById(알림이_있는_사용자.getId()).get();
+        SoftAssertions.assertSoftly(softAssertions -> {
+            final List<ReadNotificationsDto.ReadNotificationDto> notifications = actual.notifications();
+            softAssertions.assertThat(notifications).hasSize(2);
+            softAssertions.assertThat(notifications.get(0).id()).isEqualTo(친구_요청_알림1.getId());
+            softAssertions.assertThat(notifications.get(0).title()).isEqualTo(친구_요청_알림1.getTitle());
+            softAssertions.assertThat(notifications.get(1).id()).isEqualTo(친구_요청_알림2.getId());
+            softAssertions.assertThat(notifications.get(1).title()).isEqualTo(친구_요청_알림2.getTitle());
+            softAssertions.assertThat(user.isNewAlarm()).isFalse();
+        });
+    }
+
+    @Test
+    void 특정_사용자의_전체_알림_목록을_조회시_존재하지_않는_사용자라면_예외를_반환한다() {
+        assertThatThrownBy(() -> notificationService.readAllByUserId(존재하지_않는_사용자_아이디))
+                .isInstanceOf(NotFoundUserException.class);
+    }
+
+    @Test
     void 친구_요청에_대한_알림을_저장한다() {
         // when
         final Long actual = notificationService.sendRequestFriendNotification(보낸_친구_요청);
@@ -41,34 +67,29 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual).isPositive();
             softAssertions.assertThat(notification.getReceiver().getId()).isEqualTo(친구_요청을_받은_사용자.getId());
-            softAssertions.assertThat(notification.getTitle()).isEqualTo(NotificationType.REQUEST_FRIEND.getTitle());
+            softAssertions.assertThat(notification.getTitle()).isEqualTo(REQUEST_FRIEND.getTitleByFormat(null));
             softAssertions.assertThat(notification.getContent()).contains(친구_요청을_보낸_사용자.getName());
-            softAssertions.assertThat(notification.getType()).isEqualTo(NotificationType.REQUEST_FRIEND);
+            softAssertions.assertThat(notification.getType()).isEqualTo(REQUEST_FRIEND);
             softAssertions.assertThat(notification.getRequestId()).isEqualTo(친구_요청을_보낸_사용자.getId());
             softAssertions.assertThat(친구_요청을_받은_사용자.isNewAlarm()).isTrue();
         });
     }
 
     @Test
-    void 특정_사용자의_전체_알림_목록을_조회한다() {
+    void 콕_찌르기_요청에_대한_알림을_저장한다() {
         // when
-        final ReadNotificationsDto actual = notificationService.readAllByUserId(알림이_있는_사용자.getId());
+        final Long actual = notificationService.sendPokeNotification(골, 콕_찌르기_요청자, 콕_찌르기_수신자);
 
         // then
+        final Notification notification = notificationRepository.findById(actual).get();
         SoftAssertions.assertSoftly(softAssertions -> {
-            final List<ReadNotificationsDto.ReadNotificationDto> notifications = actual.notifications();
-            softAssertions.assertThat(notifications).hasSize(2);
-            softAssertions.assertThat(notifications.get(0).id()).isEqualTo(친구_요청_알림1.getId());
-            softAssertions.assertThat(notifications.get(0).title()).isEqualTo(친구_요청_알림1.getTitle());
-            softAssertions.assertThat(notifications.get(1).id()).isEqualTo(친구_요청_알림2.getId());
-            softAssertions.assertThat(notifications.get(1).title()).isEqualTo(친구_요청_알림2.getTitle());
-            softAssertions.assertThat(알림이_있는_사용자.isNewAlarm()).isFalse();
+            softAssertions.assertThat(actual).isPositive();
+            softAssertions.assertThat(notification.getReceiver().getId()).isEqualTo(콕_찌르기_수신자.getId());
+            softAssertions.assertThat(notification.getTitle()).isEqualTo(POKE.getTitleByFormat(골.getName()));
+            softAssertions.assertThat(notification.getContent()).contains(콕_찌르기_요청자.getName());
+            softAssertions.assertThat(notification.getType()).isEqualTo(POKE);
+            softAssertions.assertThat(notification.getRequestId()).isEqualTo(콕_찌르기_요청자.getId());
+            softAssertions.assertThat(콕_찌르기_수신자.isNewAlarm()).isTrue();
         });
-    }
-
-    @Test
-    void 특정_사용자의_전체_알림_목록을_조회시_존재하지_않는_사용자라면_예외를_반환한다() {
-        assertThatThrownBy(() -> notificationService.readAllByUserId(존재하지_않는_사용자_아이디))
-                .isInstanceOf(NotFoundUserException.class);
     }
 }

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
@@ -8,7 +8,7 @@ import com.backend.blooming.notification.infrastructure.repository.NotificationR
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
-import org.assertj.core.api.*;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
@@ -34,9 +34,11 @@ public class NotificationServiceTestFixture {
     @Autowired
     private NotificationRepository notificationRepository;
 
-    protected Friend 보낸_친구_요청;
+    protected Friend 친구_요청에_대한_친구;
+    protected Friend 친구_수락에_대한_친구;
     protected User 친구_요청을_보낸_사용자;
     protected User 친구_요청을_받은_사용자;
+    protected User 친구_요청을_수락한_사용자;
     protected Long 존재하지_않는_사용자_아이디 = 999L;
     protected User 알림이_있는_사용자;
     protected Notification 친구_요청_알림1;
@@ -59,28 +61,35 @@ public class NotificationServiceTestFixture {
                             .name(new Name("사용자2"))
                             .email(new Email("user2@email.com"))
                             .build();
+        친구_요청을_수락한_사용자 = User.builder()
+                            .oAuthId("12347")
+                            .oAuthType(OAuthType.KAKAO)
+                            .name(new Name("사용자3"))
+                            .email(new Email("user3@email.com"))
+                            .build();
         final User 친구_요청을_보낸_사용자1 = User.builder()
-                                        .oAuthId("12347")
-                                        .oAuthType(OAuthType.KAKAO)
-                                        .name(new Name("사용자3"))
-                                        .email(new Email("user3@email.com"))
-                                        .build();
-        final User 친구_요청을_보낸_사용자2 = User.builder()
                                         .oAuthId("12348")
                                         .oAuthType(OAuthType.KAKAO)
                                         .name(new Name("사용자4"))
                                         .email(new Email("user4@email.com"))
                                         .build();
+        final User 친구_요청을_보낸_사용자2 = User.builder()
+                                        .oAuthId("12349")
+                                        .oAuthType(OAuthType.KAKAO)
+                                        .name(new Name("사용자5"))
+                                        .email(new Email("user5@email.com"))
+                                        .build();
 
-        userRepository.saveAll(List.of(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자, 친구_요청을_보낸_사용자1, 친구_요청을_보낸_사용자2));
+        userRepository.saveAll(List.of(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자, 친구_요청을_수락한_사용자, 친구_요청을_보낸_사용자1, 친구_요청을_보낸_사용자2));
 
-        보낸_친구_요청 = new Friend(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자);
+        친구_요청에_대한_친구 = new Friend(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자);
+        친구_수락에_대한_친구 = new Friend(친구_요청을_보낸_사용자, 친구_요청을_수락한_사용자);
 
         알림이_있는_사용자 = 친구_요청을_보낸_사용자;
         final Friend 보낸_친구_요청1 = new Friend(친구_요청을_보낸_사용자1, 알림이_있는_사용자);
         final Friend 보낸_친구_요청2 = new Friend(친구_요청을_보낸_사용자2, 알림이_있는_사용자);
 
-        friendRepository.saveAll(List.of(보낸_친구_요청, 보낸_친구_요청1, 보낸_친구_요청2));
+        friendRepository.saveAll(List.of(친구_요청에_대한_친구, 친구_수락에_대한_친구, 보낸_친구_요청1, 보낸_친구_요청2));
 
         친구_요청_알림1 = Notification.builder()
                                 .receiver(알림이_있는_사용자)

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
@@ -38,6 +38,9 @@ public class NotificationServiceTestFixture {
     protected Friend 친구_수락에_대한_친구;
     protected User 친구_요청을_보낸_사용자;
     protected User 친구_요청을_받은_사용자;
+    protected User 골_관리자;
+    protected User 골_요청을_받은_사용자1;
+    protected User 골_요청을_받은_사용자2;
     protected User 친구_요청을_수락한_사용자;
     protected Long 존재하지_않는_사용자_아이디 = 999L;
     protected User 알림이_있는_사용자;
@@ -46,6 +49,8 @@ public class NotificationServiceTestFixture {
     protected User 콕_찌르기_요청자;
     protected User 콕_찌르기_수신자;
     protected Goal 골;
+    protected Goal 팀원에_관리자가_없는_골;
+    protected User 팀원에_없는_관리자;
 
     @BeforeEach
     void setUpFixture() {
@@ -62,11 +67,11 @@ public class NotificationServiceTestFixture {
                             .email(new Email("user2@email.com"))
                             .build();
         친구_요청을_수락한_사용자 = User.builder()
-                            .oAuthId("12347")
-                            .oAuthType(OAuthType.KAKAO)
-                            .name(new Name("사용자3"))
-                            .email(new Email("user3@email.com"))
-                            .build();
+                             .oAuthId("12347")
+                             .oAuthType(OAuthType.KAKAO)
+                             .name(new Name("사용자3"))
+                             .email(new Email("user3@email.com"))
+                             .build();
         final User 친구_요청을_보낸_사용자1 = User.builder()
                                         .oAuthId("12348")
                                         .oAuthType(OAuthType.KAKAO)
@@ -79,8 +84,24 @@ public class NotificationServiceTestFixture {
                                         .name(new Name("사용자5"))
                                         .email(new Email("user5@email.com"))
                                         .build();
+        골_요청을_받은_사용자2 = User.builder()
+                            .oAuthId("12350")
+                            .oAuthType(OAuthType.KAKAO)
+                            .name(new Name("사용자6"))
+                            .email(new Email("user6@email.com"))
+                            .build();
 
-        userRepository.saveAll(List.of(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자, 친구_요청을_수락한_사용자, 친구_요청을_보낸_사용자1, 친구_요청을_보낸_사용자2));
+        userRepository.saveAll(
+                List.of(
+                        친구_요청을_보낸_사용자,
+                        친구_요청을_받은_사용자,
+                        친구_요청을_수락한_사용자,
+                        친구_요청을_보낸_사용자1,
+                        친구_요청을_보낸_사용자2,
+                        골_요청을_받은_사용자2
+                )
+        );
+        골_요청을_받은_사용자1 = 친구_요청을_받은_사용자;
 
         친구_요청에_대한_친구 = new Friend(친구_요청을_보낸_사용자, 친구_요청을_받은_사용자);
         친구_수락에_대한_친구 = new Friend(친구_요청을_보낸_사용자, 친구_요청을_수락한_사용자);
@@ -111,7 +132,8 @@ public class NotificationServiceTestFixture {
 
         콕_찌르기_요청자 = 친구_요청을_보낸_사용자;
         콕_찌르기_수신자 = 친구_요청을_받은_사용자;
-        final List<User> 골_참여_사용자_목록 = List.of(콕_찌르기_요청자, 콕_찌르기_수신자);
+        골_관리자 = 콕_찌르기_요청자;
+        final List<User> 골_참여_사용자_목록 = List.of(콕_찌르기_요청자, 콕_찌르기_수신자, 골_요청을_받은_사용자2);
         골 = Goal.builder()
                 .name("골 제목")
                 .memo("골 메모")
@@ -120,6 +142,16 @@ public class NotificationServiceTestFixture {
                 .managerId(콕_찌르기_요청자.getId())
                 .users(골_참여_사용자_목록)
                 .build();
-        goalRepository.save(골);
+
+        팀원에_없는_관리자 = 친구_요청을_보낸_사용자1;
+        팀원에_관리자가_없는_골 = Goal.builder()
+                            .name("골 제목")
+                            .memo("골 메모")
+                            .startDate(LocalDate.now())
+                            .endDate(LocalDate.now().plusDays(20))
+                            .managerId(팀원에_없는_관리자.getId())
+                            .users(골_참여_사용자_목록)
+                            .build();
+        goalRepository.saveAll(List.of(골, 팀원에_관리자가_없는_골));
     }
 }

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTestFixture.java
@@ -3,6 +3,8 @@ package com.backend.blooming.notification.application;
 import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
 import com.backend.blooming.friend.domain.Friend;
 import com.backend.blooming.friend.infrastructure.repository.FriendRepository;
+import com.backend.blooming.goal.domain.Goal;
+import com.backend.blooming.goal.infrastructure.repository.GoalRepository;
 import com.backend.blooming.notification.domain.Notification;
 import com.backend.blooming.notification.infrastructure.repository.NotificationRepository;
 import com.backend.blooming.user.domain.Email;
@@ -12,6 +14,7 @@ import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
@@ -26,6 +29,9 @@ public class NotificationServiceTestFixture {
     private FriendRepository friendRepository;
 
     @Autowired
+    private GoalRepository goalRepository;
+
+    @Autowired
     private NotificationRepository notificationRepository;
 
     protected Friend 보낸_친구_요청;
@@ -35,6 +41,9 @@ public class NotificationServiceTestFixture {
     protected User 알림이_있는_사용자;
     protected Notification 친구_요청_알림1;
     protected Notification 친구_요청_알림2;
+    protected User 콕_찌르기_요청자;
+    protected User 콕_찌르기_수신자;
+    protected Goal 골;
 
     @BeforeEach
     void setUpFixture() {
@@ -75,19 +84,33 @@ public class NotificationServiceTestFixture {
 
         친구_요청_알림1 = Notification.builder()
                                 .receiver(알림이_있는_사용자)
-                                .title(REQUEST_FRIEND.getTitle())
+                                .title(REQUEST_FRIEND.getTitleByFormat(null))
                                 .content(REQUEST_FRIEND.getContentByFormat(친구_요청을_보낸_사용자1.getName()))
                                 .type(REQUEST_FRIEND)
                                 .requestId(친구_요청을_보낸_사용자1.getId())
                                 .build();
         친구_요청_알림2 = Notification.builder()
                                 .receiver(알림이_있는_사용자)
-                                .title(REQUEST_FRIEND.getTitle())
+                                .title(REQUEST_FRIEND.getTitleByFormat(null))
                                 .content(REQUEST_FRIEND.getContentByFormat(친구_요청을_보낸_사용자2.getName()))
                                 .type(REQUEST_FRIEND)
                                 .requestId(친구_요청을_보낸_사용자2.getId())
                                 .build();
+        알림이_있는_사용자.updateNewAlarm(true);
 
         notificationRepository.saveAll(List.of(친구_요청_알림1, 친구_요청_알림2));
+
+        콕_찌르기_요청자 = 친구_요청을_보낸_사용자;
+        콕_찌르기_수신자 = 친구_요청을_받은_사용자;
+        final List<User> 골_참여_사용자_목록 = List.of(콕_찌르기_요청자, 콕_찌르기_수신자);
+        골 = Goal.builder()
+                .name("골 제목")
+                .memo("골 메모")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(20))
+                .managerId(콕_찌르기_요청자.getId())
+                .users(골_참여_사용자_목록)
+                .build();
+        goalRepository.save(골);
     }
 }

--- a/src/test/java/com/backend/blooming/notification/domain/NotificationTypeTest.java
+++ b/src/test/java/com/backend/blooming/notification/domain/NotificationTypeTest.java
@@ -2,23 +2,60 @@ package com.backend.blooming.notification.domain;
 
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class NotificationTypeTest {
 
-    @Test
-    void 알림_요청의_내용을_원하는_값을_포함해_반환한다() {
-        // given
-        final String name = "사용자";
-
+    @ParameterizedTest(name = "{0} 알림 타입의 제목")
+    @MethodSource("NotificationTypeAndTitleValueAndExpectedProvider")
+    void 알림_요청의_제목을_원하는_값을_포함해_반환한다(
+            final NotificationType notificationType,
+            final String titleValue,
+            final String expected
+    ) {
         // when
-        final String actual = NotificationType.REQUEST_FRIEND.getContentByFormat(name);
+        final String actual = notificationType.getTitleByFormat(titleValue);
 
         // then
-        assertThat(actual).isEqualTo("사용자님이 회원님에게 친구 신청을 요청했습니다.");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> NotificationTypeAndTitleValueAndExpectedProvider() {
+        final String titleValue = "제목";
+        return Stream.of(
+                arguments(NotificationType.REQUEST_FRIEND, titleValue, "친구 신청"),
+                arguments(NotificationType.POKE, titleValue, "콕 찌르기 - " + titleValue)
+        );
+    }
+
+    @ParameterizedTest(name = "{0} 알림 타입의 내용")
+    @MethodSource("NotificationTypeAndContentValueAndExpectedProvider")
+    void 알림_요청의_내용을_원하는_값을_포함해_반환한다(
+            final NotificationType notificationType,
+            final String contentValue,
+            final String expected
+    ) {
+        // when
+        final String actual = notificationType.getContentByFormat(contentValue);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> NotificationTypeAndContentValueAndExpectedProvider() {
+        final String contentValue = "사용자";
+        return Stream.of(
+                arguments(NotificationType.REQUEST_FRIEND, contentValue, contentValue + "님이 회원님에게 친구 신청을 요청했습니다."),
+                arguments(NotificationType.POKE, contentValue, contentValue + "님이 회원님을 콕 찔렀습니다.")
+        );
     }
 }


### PR DESCRIPTION
- closed #68 

콕 찌르기 기능의 경우 알림을 보내는 게 끝이기에 다른 이슈로 빼기가 애매하다 판단해 함께 진행하겠습니다.
콕 찌르기 및 알림 관련 내용에 대해선 `3차 스프린트 1주차` 회의록에 작성해 두었습니다. 확인해 주시면 감사하겠습니다!
또한, `TODO`를 통해 고민을 한 가지 작성했는데 내용은 아래와 같습니다.
코드는 `TODO`를 검색해 확인하시면 보다 편하게 확인하실 수 있습니다.

추가로, 팀원인지 확인하는 로직에 대해 `Goal`에서 확인할 수 있도록 했습니다.
해당 부분이 어떤지 확인하신 후 의견 주시면 감사하겠습니다.
또한, 괜찮다면 효선님께서도 해당 메서드를 통해 검증하셔도 좋을 것 같습니다!

### 고민
1. 콕 찌르기 API의 컨트롤러 코드가 URI 상 골 패키지 내에 있는 것이 적절하다고 생각했는데, 어떻게 생각하시는지 궁금합니다.
2. 팀원 목록을 현재는 `NotificationService`에서 가져오도록 하고 있는데, 이를 `Goal`을 통해 수행하는 것이 더 적절할까요?