### PR TITLE
알림 저장 시 잘못된 requestId가 저장되는 문제 해결

### DIFF
--- a/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
+++ b/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
@@ -13,7 +13,7 @@ import com.backend.blooming.notification.infrastructure.repository.NotificationR
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
-import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.*;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -171,7 +171,7 @@ class FriendServiceTest extends FriendServiceTestFixture {
             softAssertions.assertThat(notification).hasSize(1);
             softAssertions.assertThat(notification.get(0).getId()).isPositive();
             softAssertions.assertThat(notification.get(0).getReceiver().getId()).isEqualTo(친구_요청자의_아이디);
-            softAssertions.assertThat(notification.get(0).getRequestId()).isEqualTo(이미_친구_요청을_받은_사용자_아이디);
+            softAssertions.assertThat(notification.get(0).getRequestId()).isNull();
             softAssertions.assertThat(user.isNewAlarm()).isTrue();
         });
     }

--- a/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
+++ b/src/test/java/com/backend/blooming/friend/application/FriendServiceTest.java
@@ -13,7 +13,6 @@ import com.backend.blooming.notification.infrastructure.repository.NotificationR
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
-import org.assertj.core.api.*;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -60,7 +59,7 @@ class FriendServiceTest extends FriendServiceTestFixture {
         // then
         final List<Notification> notification = notificationRepository.findAllByReceiverId(아직_친구_요청_전의_사용자_아이디);
         final User user = userRepository.findById(아직_친구_요청_전의_사용자_아이디).get();
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(notification).hasSize(1);
             softAssertions.assertThat(notification.get(0).getId()).isPositive();
             softAssertions.assertThat(notification.get(0).getReceiver().getId()).isEqualTo(아직_친구_요청_전의_사용자_아이디);
@@ -167,7 +166,7 @@ class FriendServiceTest extends FriendServiceTestFixture {
         // then
         final List<Notification> notification = notificationRepository.findAllByReceiverId(친구_요청자의_아이디);
         final User user = userRepository.findById(친구_요청자의_아이디).get();
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(notification).hasSize(1);
             softAssertions.assertThat(notification.get(0).getId()).isPositive();
             softAssertions.assertThat(notification.get(0).getReceiver().getId()).isEqualTo(친구_요청자의_아이디);

--- a/src/test/java/com/backend/blooming/goal/application/PokeServiceTest.java
+++ b/src/test/java/com/backend/blooming/goal/application/PokeServiceTest.java
@@ -9,7 +9,6 @@ import com.backend.blooming.notification.infrastructure.repository.NotificationR
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
-import org.assertj.core.api.*;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -18,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @IsolateDatabase
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -42,7 +42,7 @@ class PokeServiceTest extends PokeServiceTestFixture {
         final List<Notification> notifications = notificationRepository.findAllByReceiverId(콕_찌르기를_받은_사용자_아이디);
         final Notification pokeNotification = notifications.get(0);
         final User user = userRepository.findById(콕_찌르기를_받은_사용자_아이디).get();
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(notifications).isNotEmpty();
             softAssertions.assertThat(pokeNotification.getReceiver().getId()).isEqualTo(콕_찌르기를_받은_사용자_아이디);
             softAssertions.assertThat(pokeNotification.getType()).isEqualTo(NotificationType.POKE);

--- a/src/test/java/com/backend/blooming/goal/application/PokeServiceTest.java
+++ b/src/test/java/com/backend/blooming/goal/application/PokeServiceTest.java
@@ -9,7 +9,7 @@ import com.backend.blooming.notification.infrastructure.repository.NotificationR
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
-import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.*;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -44,9 +44,9 @@ class PokeServiceTest extends PokeServiceTestFixture {
         final User user = userRepository.findById(콕_찌르기를_받은_사용자_아이디).get();
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(notifications).isNotEmpty();
-            softAssertions.assertThat(pokeNotification.getRequestId()).isEqualTo(콕_찌르기를_요청한_사용자_아이디);
             softAssertions.assertThat(pokeNotification.getReceiver().getId()).isEqualTo(콕_찌르기를_받은_사용자_아이디);
             softAssertions.assertThat(pokeNotification.getType()).isEqualTo(NotificationType.POKE);
+            softAssertions.assertThat(pokeNotification.getRequestId()).isNull();
             softAssertions.assertThat(user.isNewAlarm()).isTrue();
         });
     }

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
@@ -8,7 +8,7 @@ import com.backend.blooming.notification.infrastructure.repository.NotificationR
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
-import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.*;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -91,7 +91,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
             softAssertions.assertThat(notification.getTitle()).isEqualTo(ACCEPT_FRIEND.getTitleByFormat(null));
             softAssertions.assertThat(notification.getContent()).contains(친구_요청을_수락한_사용자.getName());
             softAssertions.assertThat(notification.getType()).isEqualTo(ACCEPT_FRIEND);
-            softAssertions.assertThat(notification.getRequestId()).isEqualTo(친구_요청을_수락한_사용자.getId());
+            softAssertions.assertThat(notification.getRequestId()).isNull();
             softAssertions.assertThat(친구_요청을_보낸_사용자.isNewAlarm()).isTrue();
         });
     }
@@ -109,7 +109,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
             softAssertions.assertThat(notification.getTitle()).isEqualTo(POKE.getTitleByFormat(골.getName()));
             softAssertions.assertThat(notification.getContent()).contains(콕_찌르기_요청자.getName());
             softAssertions.assertThat(notification.getType()).isEqualTo(POKE);
-            softAssertions.assertThat(notification.getRequestId()).isEqualTo(콕_찌르기_요청자.getId());
+            softAssertions.assertThat(notification.getRequestId()).isNull();
             softAssertions.assertThat(콕_찌르기_수신자.isNewAlarm()).isTrue();
         });
     }
@@ -130,7 +130,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
                               .isEqualTo(REQUEST_GOAL.getTitleByFormat(골.getName()));
                 softAssertions.assertThat(notification.getContent()).contains(골_관리자.getName());
                 softAssertions.assertThat(notification.getType()).isEqualTo(REQUEST_GOAL);
-                softAssertions.assertThat(notification.getRequestId()).isEqualTo(골_관리자.getId());
+                softAssertions.assertThat(notification.getRequestId()).isNull();
                 softAssertions.assertThat(골_요청을_받은_사용자1.isNewAlarm()).isTrue();
                 softAssertions.assertThat(골_요청을_받은_사용자2.isNewAlarm()).isTrue();
             });
@@ -140,7 +140,9 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
     @Test
     void 골_초대_요청시_팀원에_골_관리자가_없다면_예외를_발생시킨다() {
         // when & then
-        assertThatThrownBy(() -> notificationService.sendRequestGoalNotification(팀원에_관리자가_없는_골, 팀원에_관리자가_없는_골.getTeams()))
-                .isInstanceOf(NotFoundGoalManagerException.class);
+        assertThatThrownBy(() -> notificationService.sendRequestGoalNotification(
+                팀원에_관리자가_없는_골,
+                팀원에_관리자가_없는_골.getTeams()
+        )).isInstanceOf(NotFoundGoalManagerException.class);
     }
 }

--- a/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
+++ b/src/test/java/com/backend/blooming/notification/application/NotificationServiceTest.java
@@ -8,7 +8,6 @@ import com.backend.blooming.notification.infrastructure.repository.NotificationR
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
-import org.assertj.core.api.*;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -21,6 +20,7 @@ import static com.backend.blooming.notification.domain.NotificationType.POKE;
 import static com.backend.blooming.notification.domain.NotificationType.REQUEST_FRIEND;
 import static com.backend.blooming.notification.domain.NotificationType.REQUEST_GOAL;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @IsolateDatabase
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -43,7 +43,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
 
         // then
         final User user = userRepository.findById(알림이_있는_사용자.getId()).get();
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             final List<ReadNotificationsDto.ReadNotificationDto> notifications = actual.notifications();
             softAssertions.assertThat(notifications).hasSize(2);
             softAssertions.assertThat(notifications.get(0).id()).isEqualTo(친구_요청_알림1.getId());
@@ -67,7 +67,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
 
         // then
         final Notification notification = notificationRepository.findById(actual).get();
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual).isPositive();
             softAssertions.assertThat(notification.getReceiver().getId()).isEqualTo(친구_요청을_받은_사용자.getId());
             softAssertions.assertThat(notification.getTitle()).isEqualTo(REQUEST_FRIEND.getTitleByFormat(null));
@@ -85,7 +85,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
 
         // then
         final Notification notification = notificationRepository.findById(actual).get();
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual).isPositive();
             softAssertions.assertThat(notification.getReceiver().getId()).isEqualTo(친구_요청을_보낸_사용자.getId());
             softAssertions.assertThat(notification.getTitle()).isEqualTo(ACCEPT_FRIEND.getTitleByFormat(null));
@@ -103,7 +103,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
 
         // then
         final Notification notification = notificationRepository.findById(actual).get();
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual).isPositive();
             softAssertions.assertThat(notification.getReceiver().getId()).isEqualTo(콕_찌르기_수신자.getId());
             softAssertions.assertThat(notification.getTitle()).isEqualTo(POKE.getTitleByFormat(골.getName()));
@@ -122,7 +122,7 @@ class NotificationServiceTest extends NotificationServiceTestFixture {
         // then
         actuals.forEach(actual -> {
             final Notification notification = notificationRepository.findById(actual).get();
-            SoftAssertions.assertSoftly(softAssertions -> {
+            assertSoftly(softAssertions -> {
                 softAssertions.assertThat(actual).isPositive();
                 softAssertions.assertThat(notification.getReceiver().getId())
                               .isIn(골_요청을_받은_사용자1.getId(), 골_요청을_받은_사용자2.getId());


### PR DESCRIPTION
- closed #80 

알림 별 저장하는 `requestId` 설정을 수정해 주었습니다.
각 알림 별 `requestId`는 다음과 같습니다.
- 친구 신청 → 친구 신청 요청자 아이디
- 친구 신청 수락 → x
- 골 팀 요청 → 골 아이디
- 콕 찌르기 → x