### PR TITLE
골 수락 기능 구현

### DIFF
--- a/src/docs/asciidoc/goal.adoc
+++ b/src/docs/asciidoc/goal.adoc
@@ -33,3 +33,9 @@ operation::goal-controller-test/요청한_아이디의_골을_삭제한다[snipp
 operation::goal-controller-test/요청한_내용으로_골을_수정한다[snippets='http-request,path-parameters,request-headers']
 ==== 응답
 operation::goal-controller-test/요청한_내용으로_골을_수정한다[snippets='http-response,response-body,response-fields']
+
+=== 골 초대 수락
+==== 요청
+operation::goal-controller-test/골_초대를_수락한다[snippets='http-request,path-parameters,request-headers']
+==== 응답
+operation::goal-controller-test/골_초대를_수락한다[snippets='http-response']

--- a/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
+++ b/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
@@ -58,6 +58,7 @@ public enum ExceptionMessage {
     UPDATE_TEAMS_FORBIDDEN("골 참여자 목록은 비어있을 수 없습니다."),
     MANAGER_GOAL_ACCEPT_INVALID("골 관리자는 골 수락을 할 수 없습니다."),
     NOT_FOUND_MANAGER("골의 관리자를 찾을 수 없습니다."),
+    FORBIDDEN_USER_TO_READ_GOAL("골을 조회할 권한이 없습니다."),
 
     // 콕 찌르기
     SENDER_NOT_IN_GOAL_TEAM("콕 찌르기 요청자가 해당 골의 팀원이 아닙니다."),

--- a/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
+++ b/src/main/java/com/backend/blooming/exception/ExceptionMessage.java
@@ -52,9 +52,11 @@ public enum ExceptionMessage {
     INVALID_GOAL_DAYS("골 날짜 수가 범위 밖입니다.(범위: 1~100)"),
     INVALID_USERS_SIZE("골 참여자 수가 범위 밖입니다.(범위: 1~5명)"),
     INVALID_USER_TO_PARTICIPATE("골에 참여할 수 없는 사용자입니다. 골에는 친구인 사용자만 초대할 수 있습니다."),
+    INVALID_GOAL_ACCEPT("초대받은 골이 아닙니다."),
     DELETE_GOAL_FORBIDDEN("골을 삭제할 권한이 없습니다."),
     UPDATE_GOAL_FORBIDDEN("골을 수정할 권한이 없습니다."),
     UPDATE_TEAMS_FORBIDDEN("골 참여자 목록은 비어있을 수 없습니다."),
+    MANAGER_GOAL_ACCEPT_INVALID("골 관리자는 골 수락을 할 수 없습니다."),
     NOT_FOUND_MANAGER("골의 관리자를 찾을 수 없습니다."),
 
     // 콕 찌르기

--- a/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import com.backend.blooming.friend.application.exception.FriendRequestNotAllowed
 import com.backend.blooming.friend.application.exception.NotFoundFriendRequestException;
 import com.backend.blooming.goal.application.exception.DeleteGoalForbiddenException;
 import com.backend.blooming.goal.application.exception.ForbiddenGoalToPokeException;
+import com.backend.blooming.goal.application.exception.ForbiddenGoalToReadException;
 import com.backend.blooming.goal.application.exception.InvalidGoalAcceptException;
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
@@ -274,6 +275,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         logWarn(exception, request);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                             .body(new ExceptionResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenGoalToReadException.class)
+    public ResponseEntity<ExceptionResponse> handleForbiddenGoalToReadException(
+            final ForbiddenGoalToReadException exception,
+            final HttpServletRequest request
+    ) {
+        logWarn(exception, request);
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
                              .body(new ExceptionResponse(exception.getMessage()));
     }
 

--- a/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/blooming/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import com.backend.blooming.friend.application.exception.FriendRequestNotAllowed
 import com.backend.blooming.friend.application.exception.NotFoundFriendRequestException;
 import com.backend.blooming.goal.application.exception.DeleteGoalForbiddenException;
 import com.backend.blooming.goal.application.exception.ForbiddenGoalToPokeException;
+import com.backend.blooming.goal.application.exception.InvalidGoalAcceptException;
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
@@ -263,6 +264,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         logWarn(exception, request);
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                             .body(new ExceptionResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidGoalAcceptException.class)
+    public ResponseEntity<ExceptionResponse> handleInvalidGoalAcceptException(
+            final InvalidGoalAcceptException exception, final HttpServletRequest request
+    ) {
+        logWarn(exception, request);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(exception.getMessage()));
     }
 

--- a/src/main/java/com/backend/blooming/goal/application/GoalService.java
+++ b/src/main/java/com/backend/blooming/goal/application/GoalService.java
@@ -5,6 +5,7 @@ import com.backend.blooming.goal.application.dto.CreateGoalDto;
 import com.backend.blooming.goal.application.dto.ReadAllGoalDto;
 import com.backend.blooming.goal.application.dto.ReadGoalDetailDto;
 import com.backend.blooming.goal.application.dto.UpdateGoalDto;
+import com.backend.blooming.goal.application.exception.InvalidGoalAcceptException;
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
@@ -141,6 +142,16 @@ public class GoalService {
     public void acceptGoalRequest(final Long userId, final Long goalId) {
         final User user = getUser(userId);
         final Goal goal = getGoal(goalId);
+        validateUserToAccept(user, goal);
         goal.updateAccepted(user.getId());
+    }
+
+    private void validateUserToAccept(final User user, final Goal goal) {
+        if (!goal.isTeam(user)) {
+            throw new InvalidGoalAcceptException.InvalidInvalidUserToAcceptGoal();
+        }
+        if (goal.isManager(user.getId())) {
+            throw new InvalidGoalAcceptException.InvalidInvalidGoalAcceptByManager();
+        }
     }
 }

--- a/src/main/java/com/backend/blooming/goal/application/GoalService.java
+++ b/src/main/java/com/backend/blooming/goal/application/GoalService.java
@@ -137,4 +137,10 @@ public class GoalService {
         final Goal goal = getGoal(goalId);
         goal.updateDeleted(user.getId());
     }
+
+    public void acceptGoalRequest(final Long userId, final Long goalId) {
+        final User user = getUser(userId);
+        final Goal goal = getGoal(goalId);
+        goal.updateAccepted(user.getId());
+    }
 }

--- a/src/main/java/com/backend/blooming/goal/application/GoalService.java
+++ b/src/main/java/com/backend/blooming/goal/application/GoalService.java
@@ -151,16 +151,6 @@ public class GoalService {
     public void acceptGoalRequest(final Long userId, final Long goalId) {
         final User user = getUser(userId);
         final Goal goal = getGoal(goalId);
-        validateUserToAccept(user, goal);
-        goal.updateAccepted(user.getId());
-    }
-
-    private void validateUserToAccept(final User user, final Goal goal) {
-        if (!goal.isTeam(user)) {
-            throw new InvalidGoalAcceptException.InvalidInvalidUserToAcceptGoal();
-        }
-        if (goal.isManager(user.getId())) {
-            throw new InvalidGoalAcceptException.InvalidInvalidGoalAcceptByManager();
-        }
+        goal.updateAccepted(user);
     }
 }

--- a/src/main/java/com/backend/blooming/goal/application/GoalService.java
+++ b/src/main/java/com/backend/blooming/goal/application/GoalService.java
@@ -5,6 +5,7 @@ import com.backend.blooming.goal.application.dto.CreateGoalDto;
 import com.backend.blooming.goal.application.dto.ReadAllGoalDto;
 import com.backend.blooming.goal.application.dto.ReadGoalDetailDto;
 import com.backend.blooming.goal.application.dto.UpdateGoalDto;
+import com.backend.blooming.goal.application.exception.ForbiddenGoalToReadException;
 import com.backend.blooming.goal.application.exception.InvalidGoalAcceptException;
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
@@ -76,10 +77,18 @@ public class GoalService {
     }
 
     @Transactional(readOnly = true)
-    public ReadGoalDetailDto readGoalDetailById(final Long goalId) {
+    public ReadGoalDetailDto readGoalDetailById(final Long goalId, final Long userId) {
         final Goal goal = getGoal(goalId);
+        final User user = getUser(userId);
+        validateUserToRead(user, goal);
 
         return ReadGoalDetailDto.from(goal);
+    }
+
+    private void validateUserToRead(final User user, final Goal goal) {
+        if (!goal.isTeam(user) || !goal.isAccepted(user)) {
+            throw new ForbiddenGoalToReadException();
+        }
     }
 
     private Goal getGoal(final Long id) {

--- a/src/main/java/com/backend/blooming/goal/application/exception/ForbiddenGoalToReadException.java
+++ b/src/main/java/com/backend/blooming/goal/application/exception/ForbiddenGoalToReadException.java
@@ -1,0 +1,11 @@
+package com.backend.blooming.goal.application.exception;
+
+import com.backend.blooming.exception.BloomingException;
+import com.backend.blooming.exception.ExceptionMessage;
+
+public class ForbiddenGoalToReadException extends BloomingException {
+
+    public ForbiddenGoalToReadException() {
+        super(ExceptionMessage.FORBIDDEN_USER_TO_READ_GOAL);
+    }
+}

--- a/src/main/java/com/backend/blooming/goal/application/exception/InvalidGoalAcceptException.java
+++ b/src/main/java/com/backend/blooming/goal/application/exception/InvalidGoalAcceptException.java
@@ -1,0 +1,25 @@
+package com.backend.blooming.goal.application.exception;
+
+import com.backend.blooming.exception.BloomingException;
+import com.backend.blooming.exception.ExceptionMessage;
+
+public class InvalidGoalAcceptException extends BloomingException {
+
+    public InvalidGoalAcceptException(final ExceptionMessage exceptionMessage) {
+        super(exceptionMessage);
+    }
+
+    public static class InvalidInvalidUserToAcceptGoal extends InvalidGoalAcceptException {
+
+        public InvalidInvalidUserToAcceptGoal() {
+            super(ExceptionMessage.INVALID_GOAL_ACCEPT);
+        }
+    }
+
+    public static class InvalidInvalidGoalAcceptByManager extends InvalidGoalAcceptException {
+
+        public InvalidInvalidGoalAcceptByManager() {
+            super(ExceptionMessage.INVALID_GOAL_ACCEPT);
+        }
+    }
+}

--- a/src/main/java/com/backend/blooming/goal/domain/Goal.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Goal.java
@@ -97,7 +97,7 @@ public class Goal extends BaseTimeEntity {
     public void updateEndDate(final LocalDate endDate) {
         this.goalTerm.updateEndDate(endDate);
     }
-    
+
     public List<GoalTeam> updateTeams(final List<User> users) {
         return this.teams.update(users, this);
     }
@@ -119,5 +119,9 @@ public class Goal extends BaseTimeEntity {
 
     public List<GoalTeam> getTeams() {
         return teams.getGoalTeams();
+    }
+
+    public void updateAccepted(final Long userId) {
+        teams.updateAccepted(userId);
     }
 }

--- a/src/main/java/com/backend/blooming/goal/domain/Goal.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Goal.java
@@ -108,9 +108,13 @@ public class Goal extends BaseTimeEntity {
     }
 
     private void validUserToDelete(final Long userId) {
-        if (!this.getManagerId().equals(userId)) {
+        if (!isManager(userId)) {
             throw new DeleteGoalForbiddenException();
         }
+    }
+
+    public boolean isManager(final Long userId) {
+        return this.getManagerId().equals(userId);
     }
 
     public boolean isTeam(final User user) {

--- a/src/main/java/com/backend/blooming/goal/domain/Goal.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Goal.java
@@ -128,4 +128,8 @@ public class Goal extends BaseTimeEntity {
     public void updateAccepted(final Long userId) {
         teams.updateAccepted(userId);
     }
+
+    public boolean isAccepted(final User user) {
+        return teams.isAccepted(user);
+    }
 }

--- a/src/main/java/com/backend/blooming/goal/domain/Goal.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Goal.java
@@ -2,6 +2,7 @@ package com.backend.blooming.goal.domain;
 
 import com.backend.blooming.common.entity.BaseTimeEntity;
 import com.backend.blooming.goal.application.exception.DeleteGoalForbiddenException;
+import com.backend.blooming.goal.application.exception.InvalidGoalAcceptException;
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.user.domain.User;
 import jakarta.persistence.Column;
@@ -125,8 +126,18 @@ public class Goal extends BaseTimeEntity {
         return teams.getGoalTeams();
     }
 
-    public void updateAccepted(final Long userId) {
-        teams.updateAccepted(userId);
+    public void updateAccepted(final User user) {
+        validateUserToAccept(user);
+        teams.updateAccepted(user.getId());
+    }
+
+    private void validateUserToAccept(final User user) {
+        if (!this.isTeam(user)) {
+            throw new InvalidGoalAcceptException.InvalidInvalidUserToAcceptGoal();
+        }
+        if (this.isManager(user.getId())) {
+            throw new InvalidGoalAcceptException.InvalidInvalidGoalAcceptByManager();
+        }
     }
 
     public boolean isAccepted(final User user) {

--- a/src/main/java/com/backend/blooming/goal/domain/GoalTeam.java
+++ b/src/main/java/com/backend/blooming/goal/domain/GoalTeam.java
@@ -37,10 +37,24 @@ public class GoalTeam extends BaseTimeEntity {
     private Goal goal;
 
     @Column(nullable = false)
+    private boolean accepted = false;
+
+    @Column(nullable = false)
     private boolean deleted = false;
 
     public GoalTeam(final User user, final Goal goal) {
         this.user = user;
         this.goal = goal;
+        validateUserIsManager(user, goal);
+    }
+
+    public void updateAccepted() {
+        this.accepted = true;
+    }
+
+    private void validateUserIsManager(final User user, final Goal goal) {
+        if (goal.getManagerId().equals(user.getId())) {
+            updateAccepted();
+        }
     }
 }

--- a/src/main/java/com/backend/blooming/goal/domain/Teams.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Teams.java
@@ -73,4 +73,9 @@ public class Teams {
             }
         });
     }
+
+    public boolean isAccepted(final User user) {
+        return goalTeams.stream()
+                        .anyMatch(goalTeam -> goalTeam.getUser().equals(user) && goalTeam.isAccepted());
+    }
 }

--- a/src/main/java/com/backend/blooming/goal/domain/Teams.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Teams.java
@@ -65,4 +65,12 @@ public class Teams {
         return goalTeams.stream()
                         .anyMatch(goalTeam -> goalTeam.getUser().equals(user));
     }
+
+    public void updateAccepted(final Long userId) {
+        this.goalTeams.forEach(goalTeam -> {
+            if (goalTeam.getUser().getId().equals(userId)) {
+                goalTeam.updateAccepted();
+            }
+        });
+    }
 }

--- a/src/main/java/com/backend/blooming/goal/presentation/GoalController.java
+++ b/src/main/java/com/backend/blooming/goal/presentation/GoalController.java
@@ -102,4 +102,15 @@ public class GoalController {
         return ResponseEntity.noContent()
                              .build();
     }
+
+    @PostMapping(value = "/{goalId}/accept", headers = "X-API-VERSION=1")
+    public ResponseEntity<Void> acceptGoal(
+            @PathVariable("goalId") final Long goalId,
+            @Authenticated final AuthenticatedUser authenticatedUser
+    ) {
+        goalService.acceptGoalRequest(authenticatedUser.userId(), goalId);
+
+        return ResponseEntity.noContent()
+                             .build();
+    }
 }

--- a/src/main/java/com/backend/blooming/goal/presentation/GoalController.java
+++ b/src/main/java/com/backend/blooming/goal/presentation/GoalController.java
@@ -46,8 +46,11 @@ public class GoalController {
     }
 
     @GetMapping(value = "/{goalId}", headers = "X-API-VERSION=1")
-    public ResponseEntity<ReadGoalResponse> readGoalById(@PathVariable("goalId") final Long goalId) {
-        final ReadGoalDetailDto readGoalDetailDto = goalService.readGoalDetailById(goalId);
+    public ResponseEntity<ReadGoalResponse> readGoalById(
+            @PathVariable("goalId") final Long goalId,
+            @Authenticated final AuthenticatedUser authenticatedUser
+    ) {
+        final ReadGoalDetailDto readGoalDetailDto = goalService.readGoalDetailById(goalId, authenticatedUser.userId());
         final ReadGoalResponse response = ReadGoalResponse.from(readGoalDetailDto);
 
         return ResponseEntity.ok(response);

--- a/src/main/resources/static/docs/authentication.html
+++ b/src/main/resources/static/docs/authentication.html
@@ -669,7 +669,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-28 21:29:55 +0900
+Last updated 2024-01-26 08:53:29 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/docs.html
+++ b/src/main/resources/static/docs/docs.html
@@ -824,7 +824,6 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "사용자",
-  "profileImageUrl" : "https://blooming.default.image.png",
   "color" : "#96b0e5",
   "statusMessage" : "반갑습니다."
 }</code></pre>
@@ -868,11 +867,6 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
@@ -952,7 +946,6 @@ Content-Type: application/json
     "id" : 1,
     "email" : "teat1@email.com",
     "name" : "사용자1",
-    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#96b0e5",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "SELF"
@@ -960,7 +953,6 @@ Content-Type: application/json
     "id" : 2,
     "email" : "teat2@email.com",
     "name" : "사용자2",
-    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#f69b94",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "FRIENDS"
@@ -1003,11 +995,6 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].profileImageUrl</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].color</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 테마 색상 코드</p></td>
@@ -1033,9 +1020,15 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /users HTTP/1.1
-Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Type: application/json;charset=UTF-8
 X-API-VERSION: 1
-Authorization: Bearer access_token</code></pre>
+Authorization: Bearer access_token
+
+{
+  "name" : "수정한 이름",
+  "color" : "BLUE",
+  "statusMessage" : "수정한 상태 메시지"
+}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1105,8 +1098,7 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "수정한 이름",
-  "profileImageUrl" : "https://blooming.update.image.png",
-  "color" : "BLUE",
+  "color" : "#96b0e5",
   "statusMessage" : "수정한 상태 메시지"
 }</code></pre>
 </div>
@@ -1149,11 +1141,6 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
@@ -1306,7 +1293,6 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "사용자",
-  "profileImageUrl" : "https://blooming.default.image.png",
   "color" : "#96b0e5",
   "statusMessage" : "반갑습니다."
 }</code></pre>
@@ -1350,11 +1336,6 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
@@ -1434,7 +1415,6 @@ Content-Type: application/json
     "id" : 1,
     "email" : "teat1@email.com",
     "name" : "사용자1",
-    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#96b0e5",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "SELF"
@@ -1442,7 +1422,6 @@ Content-Type: application/json
     "id" : 2,
     "email" : "teat2@email.com",
     "name" : "사용자2",
-    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#f69b94",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "FRIENDS"
@@ -1485,11 +1464,6 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].profileImageUrl</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].color</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 테마 색상 코드</p></td>
@@ -1515,9 +1489,15 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /users HTTP/1.1
-Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Type: application/json;charset=UTF-8
 X-API-VERSION: 1
-Authorization: Bearer access_token</code></pre>
+Authorization: Bearer access_token
+
+{
+  "name" : "수정한 이름",
+  "color" : "BLUE",
+  "statusMessage" : "수정한 상태 메시지"
+}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1587,8 +1567,7 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "수정한 이름",
-  "profileImageUrl" : "https://blooming.update.image.png",
-  "color" : "BLUE",
+  "color" : "#96b0e5",
   "statusMessage" : "수정한 상태 메시지"
 }</code></pre>
 </div>
@@ -1631,11 +1610,6 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
@@ -2326,8 +2300,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-03-04",
-  "endDate" : "2024-03-14",
+  "startDate" : "2024-03-10",
+  "endDate" : "2024-03-20",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -2499,8 +2473,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-04",
-  "endDate" : "2024-03-14",
+  "startDate" : "2024-03-10",
+  "endDate" : "2024-03-20",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -2526,8 +2500,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-04",
-  "endDate" : "2024-03-14",
+  "startDate" : "2024-03-10",
+  "endDate" : "2024-03-20",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -2674,8 +2648,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-04",
-    "endDate" : "2024-03-14",
+    "startDate" : "2024-03-10",
+    "endDate" : "2024-03-20",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -2699,8 +2673,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-04",
-    "endDate" : "2024-03-14",
+    "startDate" : "2024-03-10",
+    "endDate" : "2024-03-20",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -2830,8 +2804,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-04",
-    "endDate" : "2024-03-09",
+    "startDate" : "2024-03-10",
+    "endDate" : "2024-03-15",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -2855,8 +2829,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-04",
-    "endDate" : "2024-03-09",
+    "startDate" : "2024-03-10",
+    "endDate" : "2024-03-15",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -3023,7 +2997,7 @@ Authorization: Bearer access_token
 {
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "endDate" : "2024-03-24",
+  "endDate" : "2024-03-30",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -3090,8 +3064,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-04",
-  "endDate" : "2024-03-24",
+  "startDate" : "2024-03-10",
+  "endDate" : "2024-03-30",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -3122,8 +3096,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-04",
-  "endDate" : "2024-03-24",
+  "startDate" : "2024-03-10",
+  "endDate" : "2024-03-30",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {

--- a/src/main/resources/static/docs/docs.html
+++ b/src/main/resources/static/docs/docs.html
@@ -824,6 +824,7 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "사용자",
+  "profileImageUrl" : "https://blooming.default.image.png",
   "color" : "#96b0e5",
   "statusMessage" : "반갑습니다."
 }</code></pre>
@@ -867,6 +868,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
@@ -946,6 +952,7 @@ Content-Type: application/json
     "id" : 1,
     "email" : "teat1@email.com",
     "name" : "사용자1",
+    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#96b0e5",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "SELF"
@@ -953,6 +960,7 @@ Content-Type: application/json
     "id" : 2,
     "email" : "teat2@email.com",
     "name" : "사용자2",
+    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#f69b94",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "FRIENDS"
@@ -995,6 +1003,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].profileImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].color</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 테마 색상 코드</p></td>
@@ -1020,15 +1033,9 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /users HTTP/1.1
-Content-Type: application/json;charset=UTF-8
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 X-API-VERSION: 1
-Authorization: Bearer access_token
-
-{
-  "name" : "수정한 이름",
-  "color" : "BLUE",
-  "statusMessage" : "수정한 상태 메시지"
-}</code></pre>
+Authorization: Bearer access_token</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1098,7 +1105,8 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "수정한 이름",
-  "color" : "#96b0e5",
+  "profileImageUrl" : "https://blooming.update.image.png",
+  "color" : "BLUE",
   "statusMessage" : "수정한 상태 메시지"
 }</code></pre>
 </div>
@@ -1141,6 +1149,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
@@ -1293,6 +1306,7 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "사용자",
+  "profileImageUrl" : "https://blooming.default.image.png",
   "color" : "#96b0e5",
   "statusMessage" : "반갑습니다."
 }</code></pre>
@@ -1336,6 +1350,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
@@ -1415,6 +1434,7 @@ Content-Type: application/json
     "id" : 1,
     "email" : "teat1@email.com",
     "name" : "사용자1",
+    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#96b0e5",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "SELF"
@@ -1422,6 +1442,7 @@ Content-Type: application/json
     "id" : 2,
     "email" : "teat2@email.com",
     "name" : "사용자2",
+    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#f69b94",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "FRIENDS"
@@ -1464,6 +1485,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].profileImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].color</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 테마 색상 코드</p></td>
@@ -1489,15 +1515,9 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /users HTTP/1.1
-Content-Type: application/json;charset=UTF-8
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 X-API-VERSION: 1
-Authorization: Bearer access_token
-
-{
-  "name" : "수정한 이름",
-  "color" : "BLUE",
-  "statusMessage" : "수정한 상태 메시지"
-}</code></pre>
+Authorization: Bearer access_token</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1567,7 +1587,8 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "수정한 이름",
-  "color" : "#96b0e5",
+  "profileImageUrl" : "https://blooming.update.image.png",
+  "color" : "BLUE",
   "statusMessage" : "수정한 상태 메시지"
 }</code></pre>
 </div>
@@ -1610,6 +1631,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
@@ -2300,8 +2326,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-02-18",
-  "endDate" : "2024-02-28",
+  "startDate" : "2024-03-04",
+  "endDate" : "2024-03-14",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -2473,8 +2499,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-02-18",
-  "endDate" : "2024-02-28",
+  "startDate" : "2024-03-04",
+  "endDate" : "2024-03-14",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -2500,8 +2526,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-02-18",
-  "endDate" : "2024-02-28",
+  "startDate" : "2024-03-04",
+  "endDate" : "2024-03-14",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -2648,8 +2674,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-02-18",
-    "endDate" : "2024-02-28",
+    "startDate" : "2024-03-04",
+    "endDate" : "2024-03-14",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -2673,8 +2699,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-02-18",
-    "endDate" : "2024-02-28",
+    "startDate" : "2024-03-04",
+    "endDate" : "2024-03-14",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -2804,8 +2830,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-02-18",
-    "endDate" : "2024-02-23",
+    "startDate" : "2024-03-04",
+    "endDate" : "2024-03-09",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -2829,8 +2855,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-02-18",
-    "endDate" : "2024-02-23",
+    "startDate" : "2024-03-04",
+    "endDate" : "2024-03-09",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -2997,7 +3023,7 @@ Authorization: Bearer access_token
 {
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "endDate" : "2024-03-09",
+  "endDate" : "2024-03-24",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -3064,8 +3090,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-02-18",
-  "endDate" : "2024-03-09",
+  "startDate" : "2024-03-04",
+  "endDate" : "2024-03-24",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -3096,8 +3122,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-02-18",
-  "endDate" : "2024-03-09",
+  "startDate" : "2024-03-04",
+  "endDate" : "2024-03-24",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -3286,7 +3312,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-18 03:44:47 +0900
+Last updated 2024-03-04 01:27:35 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/docs.html
+++ b/src/main/resources/static/docs/docs.html
@@ -490,6 +490,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_현재_로그인한_사용자가_참여한_종료된_모든_골_조회">현재 로그인한 사용자가 참여한 종료된 모든 골 조회</a></li>
 <li><a href="#_골_삭제">골 삭제</a></li>
 <li><a href="#_골_수정">골 수정</a></li>
+<li><a href="#_골_초대_수락">골 초대 수락</a></li>
 </ul>
 </li>
 <li><a href="#_콕_찌르기">콕 찌르기</a>
@@ -3196,25 +3197,42 @@ Content-Type: application/json
 </div>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_콕_찌르기"><a class="link" href="#_콕_찌르기">콕 찌르기</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_콕_찌르기_요청"><a class="link" href="#_콕_찌르기_요청">콕 찌르기 요청</a></h3>
+<h3 id="_골_초대_수락"><a class="link" href="#_골_초대_수락">골 초대 수락</a></h3>
 <div class="sect3">
 <h4 id="_요청_22"><a class="link" href="#_요청_22">요청</a></h4>
 <div class="sect4">
 <h5 id="_요청_22_http_request"><a class="link" href="#_요청_22_http_request">HTTP request</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /goals/1/poke/2 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /goals/1/accept HTTP/1.1
 X-API-VERSION: 1
 Authorization: Bearer access_token
 Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
+</div>
+<div class="sect4">
+<h5 id="_요청_22_path_parameters"><a class="link" href="#_요청_22_path_parameters">Path parameters</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 2. /goals/{goalId}/accept</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>goalId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 골 아이디</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect4">
 <h5 id="_요청_22_request_headers"><a class="link" href="#_요청_22_request_headers">Request headers</a></h5>
@@ -3241,8 +3259,66 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 </tbody>
 </table>
 </div>
+</div>
+<div class="sect3">
+<h4 id="_응답_22"><a class="link" href="#_응답_22">응답</a></h4>
 <div class="sect4">
-<h5 id="_요청_22_path_parameters"><a class="link" href="#_요청_22_path_parameters">Path parameters</a></h5>
+<h5 id="_응답_22_http_response"><a class="link" href="#_응답_22_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_콕_찌르기"><a class="link" href="#_콕_찌르기">콕 찌르기</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_콕_찌르기_요청"><a class="link" href="#_콕_찌르기_요청">콕 찌르기 요청</a></h3>
+<div class="sect3">
+<h4 id="_요청_23"><a class="link" href="#_요청_23">요청</a></h4>
+<div class="sect4">
+<h5 id="_요청_23_http_request"><a class="link" href="#_요청_23_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /goals/1/poke/2 HTTP/1.1
+X-API-VERSION: 1
+Authorization: Bearer access_token
+Content-Type: application/x-www-form-urlencoded</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_요청_23_request_headers"><a class="link" href="#_요청_23_request_headers">Request headers</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>X-API-VERSION</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청 버전</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_요청_23_path_parameters"><a class="link" href="#_요청_23_path_parameters">Path parameters</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 2. /goals/{goalId}/poke/{userId}</caption>
 <colgroup>
@@ -3269,9 +3345,9 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_응답_22"><a class="link" href="#_응답_22">응답</a></h4>
+<h4 id="_응답_23"><a class="link" href="#_응답_23">응답</a></h4>
 <div class="sect4">
-<h5 id="_응답_22_http_response"><a class="link" href="#_응답_22_http_response">HTTP response</a></h5>
+<h5 id="_응답_23_http_response"><a class="link" href="#_응답_23_http_response">HTTP response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content</code></pre>

--- a/src/main/resources/static/docs/friend.html
+++ b/src/main/resources/static/docs/friend.html
@@ -1093,7 +1093,7 @@ Authorization: Bearer access_token</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-28 21:29:55 +0900
+Last updated 2024-01-26 08:53:29 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/goal.html
+++ b/src/main/resources/static/docs/goal.html
@@ -456,8 +456,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-02-18",
-  "endDate" : "2024-02-28",
+  "startDate" : "2024-03-04",
+  "endDate" : "2024-03-14",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -629,8 +629,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-02-18",
-  "endDate" : "2024-02-28",
+  "startDate" : "2024-03-04",
+  "endDate" : "2024-03-14",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -656,8 +656,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-02-18",
-  "endDate" : "2024-02-28",
+  "startDate" : "2024-03-04",
+  "endDate" : "2024-03-14",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -804,8 +804,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-02-18",
-    "endDate" : "2024-02-28",
+    "startDate" : "2024-03-04",
+    "endDate" : "2024-03-14",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -829,8 +829,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-02-18",
-    "endDate" : "2024-02-28",
+    "startDate" : "2024-03-04",
+    "endDate" : "2024-03-14",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -960,8 +960,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-02-18",
-    "endDate" : "2024-02-23",
+    "startDate" : "2024-03-04",
+    "endDate" : "2024-03-09",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -985,8 +985,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-02-18",
-    "endDate" : "2024-02-23",
+    "startDate" : "2024-03-04",
+    "endDate" : "2024-03-09",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -1153,7 +1153,7 @@ Authorization: Bearer access_token
 {
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "endDate" : "2024-03-09",
+  "endDate" : "2024-03-24",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -1220,8 +1220,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-02-18",
-  "endDate" : "2024-03-09",
+  "startDate" : "2024-03-04",
+  "endDate" : "2024-03-24",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -1252,8 +1252,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-02-18",
-  "endDate" : "2024-03-09",
+  "startDate" : "2024-03-04",
+  "endDate" : "2024-03-24",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -1356,7 +1356,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-17 00:43:03 +0900
+Last updated 2024-02-18 13:48:10 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/goal.html
+++ b/src/main/resources/static/docs/goal.html
@@ -1352,11 +1352,86 @@ Content-Type: application/json
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_골_초대_수락">골 초대 수락</h3>
+<div class="sect3">
+<h4 id="_요청_7">요청</h4>
+<div class="sect4">
+<h5 id="_요청_7_http_request">HTTP request</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /goals/1/accept HTTP/1.1
+X-API-VERSION: 1
+Authorization: Bearer access_token
+Content-Type: application/x-www-form-urlencoded</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_요청_7_path_parameters">Path parameters</h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /goals/{goalId}/accept</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>goalId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 골 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_요청_7_request_headers">Request headers</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>X-API-VERSION</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청 버전</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_7">응답</h4>
+<div class="sect4">
+<h5 id="_응답_7_http_response">HTTP response</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-18 13:48:10 +0900
+Last updated 2024-03-10 02:07:03 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/goal.html
+++ b/src/main/resources/static/docs/goal.html
@@ -456,8 +456,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-03-04",
-  "endDate" : "2024-03-14",
+  "startDate" : "2024-03-10",
+  "endDate" : "2024-03-20",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -629,8 +629,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-04",
-  "endDate" : "2024-03-14",
+  "startDate" : "2024-03-10",
+  "endDate" : "2024-03-20",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -656,8 +656,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-04",
-  "endDate" : "2024-03-14",
+  "startDate" : "2024-03-10",
+  "endDate" : "2024-03-20",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -804,8 +804,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-04",
-    "endDate" : "2024-03-14",
+    "startDate" : "2024-03-10",
+    "endDate" : "2024-03-20",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -829,8 +829,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-04",
-    "endDate" : "2024-03-14",
+    "startDate" : "2024-03-10",
+    "endDate" : "2024-03-20",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -960,8 +960,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-04",
-    "endDate" : "2024-03-09",
+    "startDate" : "2024-03-10",
+    "endDate" : "2024-03-15",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -985,8 +985,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-04",
-    "endDate" : "2024-03-09",
+    "startDate" : "2024-03-10",
+    "endDate" : "2024-03-15",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -1153,7 +1153,7 @@ Authorization: Bearer access_token
 {
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "endDate" : "2024-03-24",
+  "endDate" : "2024-03-30",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -1220,8 +1220,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-04",
-  "endDate" : "2024-03-24",
+  "startDate" : "2024-03-10",
+  "endDate" : "2024-03-30",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -1252,8 +1252,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-04",
-  "endDate" : "2024-03-24",
+  "startDate" : "2024-03-10",
+  "endDate" : "2024-03-30",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {

--- a/src/main/resources/static/docs/notification.html
+++ b/src/main/resources/static/docs/notification.html
@@ -550,7 +550,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-01 20:29:52 +0900
+Last updated 2024-02-01 19:10:19 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/poke.html
+++ b/src/main/resources/static/docs/poke.html
@@ -523,7 +523,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-18 03:44:22 +0900
+Last updated 2024-03-03 01:19:55 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/stamp.html
+++ b/src/main/resources/static/docs/stamp.html
@@ -590,7 +590,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-17 00:19:23 +0900
+Last updated 2024-03-03 14:09:39 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/themecolor.html
+++ b/src/main/resources/static/docs/themecolor.html
@@ -524,7 +524,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-28 21:29:55 +0900
+Last updated 2024-01-26 08:53:29 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/user.html
+++ b/src/main/resources/static/docs/user.html
@@ -487,6 +487,7 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "사용자",
+  "profileImageUrl" : "https://blooming.default.image.png",
   "color" : "#96b0e5",
   "statusMessage" : "반갑습니다."
 }</code></pre>
@@ -530,6 +531,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
@@ -609,6 +615,7 @@ Content-Type: application/json
     "id" : 1,
     "email" : "teat1@email.com",
     "name" : "사용자1",
+    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#96b0e5",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "SELF"
@@ -616,6 +623,7 @@ Content-Type: application/json
     "id" : 2,
     "email" : "teat2@email.com",
     "name" : "사용자2",
+    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#f69b94",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "FRIENDS"
@@ -658,6 +666,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].profileImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].color</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 테마 색상 코드</p></td>
@@ -683,15 +696,9 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /users HTTP/1.1
-Content-Type: application/json;charset=UTF-8
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 X-API-VERSION: 1
-Authorization: Bearer access_token
-
-{
-  "name" : "수정한 이름",
-  "color" : "BLUE",
-  "statusMessage" : "수정한 상태 메시지"
-}</code></pre>
+Authorization: Bearer access_token</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -761,7 +768,8 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "수정한 이름",
-  "color" : "#96b0e5",
+  "profileImageUrl" : "https://blooming.update.image.png",
+  "color" : "BLUE",
   "statusMessage" : "수정한 상태 메시지"
 }</code></pre>
 </div>
@@ -806,6 +814,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 테마 색상</p></td>
@@ -823,7 +836,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-28 21:29:55 +0900
+Last updated 2024-01-26 08:53:29 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/user.html
+++ b/src/main/resources/static/docs/user.html
@@ -487,7 +487,6 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "사용자",
-  "profileImageUrl" : "https://blooming.default.image.png",
   "color" : "#96b0e5",
   "statusMessage" : "반갑습니다."
 }</code></pre>
@@ -531,11 +530,6 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>
@@ -615,7 +609,6 @@ Content-Type: application/json
     "id" : 1,
     "email" : "teat1@email.com",
     "name" : "사용자1",
-    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#96b0e5",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "SELF"
@@ -623,7 +616,6 @@ Content-Type: application/json
     "id" : 2,
     "email" : "teat2@email.com",
     "name" : "사용자2",
-    "profileImageUrl" : "https://blooming.default.image.png",
     "color" : "#f69b94",
     "statusMessage" : "상태 메시지",
     "friendsStatus" : "FRIENDS"
@@ -666,11 +658,6 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].profileImageUrl</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>users.[].color</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 테마 색상 코드</p></td>
@@ -696,9 +683,15 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /users HTTP/1.1
-Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Type: application/json;charset=UTF-8
 X-API-VERSION: 1
-Authorization: Bearer access_token</code></pre>
+Authorization: Bearer access_token
+
+{
+  "name" : "수정한 이름",
+  "color" : "BLUE",
+  "statusMessage" : "수정한 상태 메시지"
+}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -768,8 +761,7 @@ Content-Type: application/json
   "oAuthType" : "KAKAO",
   "email" : "test@email.com",
   "name" : "수정한 이름",
-  "profileImageUrl" : "https://blooming.update.image.png",
-  "color" : "BLUE",
+  "color" : "#96b0e5",
   "statusMessage" : "수정한 상태 메시지"
 }</code></pre>
 </div>
@@ -812,11 +804,6 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImageUrl</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 이미지 url</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>color</code></p></td>

--- a/src/test/java/com/backend/blooming/goal/application/GoalServiceTest.java
+++ b/src/test/java/com/backend/blooming/goal/application/GoalServiceTest.java
@@ -4,6 +4,7 @@ import com.backend.blooming.configuration.IsolateDatabase;
 import com.backend.blooming.goal.application.dto.ReadAllGoalDto;
 import com.backend.blooming.goal.application.dto.ReadGoalDetailDto;
 import com.backend.blooming.goal.application.exception.DeleteGoalForbiddenException;
+import com.backend.blooming.goal.application.exception.ForbiddenGoalToReadException;
 import com.backend.blooming.goal.application.exception.InvalidGoalAcceptException;
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
@@ -58,7 +59,7 @@ class GoalServiceTest extends GoalServiceTestFixture {
     @Test
     void 골_아이디로_해당_골_정보를_조회한다() {
         // when
-        final ReadGoalDetailDto result = goalService.readGoalDetailById(유효한_골_아이디);
+        final ReadGoalDetailDto result = goalService.readGoalDetailById(유효한_골_아이디, 유효한_사용자_아이디);
 
         // then
         assertSoftly(softAssertions -> {
@@ -80,8 +81,22 @@ class GoalServiceTest extends GoalServiceTestFixture {
     @Test
     void 존재하지_않는_골_아이디를_조회한_경우_예외를_발생한다() {
         // when & then
-        assertThatThrownBy(() -> goalService.readGoalDetailById(존재하지_않는_골_아이디))
+        assertThatThrownBy(() -> goalService.readGoalDetailById(존재하지_않는_골_아이디, 유효한_사용자_아이디))
                 .isInstanceOf(NotFoundGoalException.class);
+    }
+
+    @Test
+    void 골_참여자가_아닌_사용자가_조회한_경우_예외를_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> goalService.readGoalDetailById(유효한_골_아이디, 친구인_사용자2.getId()))
+                .isInstanceOf(ForbiddenGoalToReadException.class);
+    }
+
+    @Test
+    void 골_초대를_수락하지_않은_사용자가_조회한_경우_예외를_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> goalService.readGoalDetailById(유효한_골_아이디, 친구인_사용자.getId()))
+                .isInstanceOf(ForbiddenGoalToReadException.class);
     }
 
     @Test

--- a/src/test/java/com/backend/blooming/goal/application/GoalServiceTest.java
+++ b/src/test/java/com/backend/blooming/goal/application/GoalServiceTest.java
@@ -4,6 +4,7 @@ import com.backend.blooming.configuration.IsolateDatabase;
 import com.backend.blooming.goal.application.dto.ReadAllGoalDto;
 import com.backend.blooming.goal.application.dto.ReadGoalDetailDto;
 import com.backend.blooming.goal.application.exception.DeleteGoalForbiddenException;
+import com.backend.blooming.goal.application.exception.InvalidGoalAcceptException;
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
@@ -310,5 +311,19 @@ class GoalServiceTest extends GoalServiceTestFixture {
             softAssertions.assertThat(acceptedGoalTeam.get(0).getUser().getId()).isEqualTo(유효한_사용자_아이디);
             softAssertions.assertThat(acceptedGoalTeam.get(1).getUser().getId()).isEqualTo(골_관리자가_아닌_사용자_아이디);
         });
+    }
+
+    @Test
+    void 골에_초대되지_않은_사람이_골_수락을_요청한_경우_예외를_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> goalService.acceptGoalRequest(친구인_사용자2.getId(), 현재_진행중인_골1.getId()))
+                .isInstanceOf(InvalidGoalAcceptException.InvalidInvalidUserToAcceptGoal.class);
+    }
+
+    @Test
+    void 골_관리자가_골_수락을_요청한_경우_예외를_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> goalService.acceptGoalRequest(유효한_사용자_아이디, 현재_진행중인_골1.getId()))
+                .isInstanceOf(InvalidGoalAcceptException.InvalidInvalidGoalAcceptByManager.class);
     }
 }

--- a/src/test/java/com/backend/blooming/goal/application/GoalServiceTest.java
+++ b/src/test/java/com/backend/blooming/goal/application/GoalServiceTest.java
@@ -7,11 +7,13 @@ import com.backend.blooming.goal.application.exception.DeleteGoalForbiddenExcept
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
+import com.backend.blooming.goal.domain.GoalTeam;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -25,38 +27,38 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class GoalServiceTest extends GoalServiceTestFixture {
-    
+
     @Autowired
     private GoalService goalService;
-    
+
     @Test
     void 새로운_골을_생성한다() {
         // when
         final Long goalId = goalService.createGoal(유효한_골_생성_dto);
-        
+
         // then
         assertThat(goalId).isPositive();
     }
-    
+
     @Test
     void 골_생성시_존재하지_않는_사용자가_관리자인_경우_예외를_발생한다() {
         // when
         assertThatThrownBy(() -> goalService.createGoal(존재하지_않는_사용자가_관리자인_골_생성_dto))
                 .isInstanceOf(NotFoundUserException.class);
     }
-    
+
     @Test
     void 골_생성시_친구가_아닌_사용자가_참여자로_있는_경우_예외를_발생한다() {
         // when
         assertThatThrownBy(() -> goalService.createGoal(친구가_아닌_사용자가_참여자로_있는_골_생성_dto))
                 .isInstanceOf(InvalidGoalException.InvalidInvalidUserToParticipate.class);
     }
-    
+
     @Test
     void 골_아이디로_해당_골_정보를_조회한다() {
         // when
         final ReadGoalDetailDto result = goalService.readGoalDetailById(유효한_골_아이디);
-        
+
         // then
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(result.name()).isEqualTo(골_제목);
@@ -73,14 +75,14 @@ class GoalServiceTest extends GoalServiceTestFixture {
             softAssertions.assertThat(result.teams().get(1).id()).isEqualTo(유효한_골_dto.teams().get(1).id());
         });
     }
-    
+
     @Test
     void 존재하지_않는_골_아이디를_조회한_경우_예외를_발생한다() {
         // when & then
         assertThatThrownBy(() -> goalService.readGoalDetailById(존재하지_않는_골_아이디))
                 .isInstanceOf(NotFoundGoalException.class);
     }
-    
+
     @Test
     void 현재_로그인한_사용자가_참여한_골_중_현재_진행중인_모든_골_정보를_조회한다() {
         // when
@@ -88,7 +90,7 @@ class GoalServiceTest extends GoalServiceTestFixture {
                 유효한_사용자_아이디,
                 LocalDate.now().plusDays(테스트를_위한_시스템_현재_시간_설정값)
         );
-        
+
         // then
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(result.goalInfos()).hasSize(2);
@@ -98,7 +100,7 @@ class GoalServiceTest extends GoalServiceTestFixture {
             softAssertions.assertThat(result.goalInfos().get(1).name()).isEqualTo(현재_진행중인_골2.getName());
         });
     }
-    
+
     @Test
     void 현재_로그인한_사용자가_참여한_골_중_종료된_모든_골_정보를_조회한다() {
         // when
@@ -106,7 +108,7 @@ class GoalServiceTest extends GoalServiceTestFixture {
                 유효한_사용자_아이디,
                 LocalDate.now().plusDays(테스트를_위한_시스템_현재_시간_설정값)
         );
-        
+
         // then
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(result.goalInfos()).hasSize(2);
@@ -116,36 +118,36 @@ class GoalServiceTest extends GoalServiceTestFixture {
             softAssertions.assertThat(result.goalInfos().get(1).name()).isEqualTo(이미_종료된_골2.getName());
         });
     }
-    
+
     @Test
     void 요청받은_골의_아이디에_해당하는_골을_삭제한다() {
         // when & then
         assertThatCode(() -> goalService.delete(유효한_사용자_아이디, 유효한_골_아이디)).doesNotThrowAnyException();
     }
-    
+
     @Test
     void 존재하지_않는_골_아이디를_삭제_요청했을_때_예외를_발생한다() {
         assertThatThrownBy(() -> goalService.delete(유효한_사용자_아이디, 유효하지_않은_골_아이디))
                 .isInstanceOf(NotFoundGoalException.class);
     }
-    
+
     @Test
     void 존재하지_않는_사용자가_삭제를_요청했을_때_예외를_발생한다() {
         assertThatThrownBy(() -> goalService.delete(존재하지_않는_사용자_아이디, 유효한_골_아이디))
                 .isInstanceOf(NotFoundUserException.class);
     }
-    
+
     @Test
     void 삭제_요청한_사용자가_관리자가_아닌_경우_예외를_발생한다() {
         assertThatThrownBy(() -> goalService.delete(골_관리자가_아닌_사용자_아이디, 유효한_골_아이디))
                 .isInstanceOf(DeleteGoalForbiddenException.class);
     }
-    
+
     @Test
     void 골을_요청받은_내용으로_수정한다() {
         // when
         final ReadGoalDetailDto result = goalService.update(유효한_사용자_아이디, 유효한_골_아이디, 수정_요청한_골_dto);
-        
+
         // then
         assertSoftly(softAssertions -> {
             final List<ReadGoalDetailDto.GoalTeamDto> teams = result.teams();
@@ -158,33 +160,33 @@ class GoalServiceTest extends GoalServiceTestFixture {
             softAssertions.assertThat(teams.get(2).id()).isEqualTo(친구인_사용자2.getId());
         });
     }
-    
+
     @Test
     void 골_수정을_요청한_사용자가_존재하지_않을시_예외를_발생한다() {
         // when & then
         assertThatThrownBy(() -> goalService.update(존재하지_않는_사용자_아이디, 유효한_골_아이디, 수정_요청한_골_dto))
                 .isInstanceOf(NotFoundUserException.class);
     }
-    
+
     @Test
     void 수정_요청한_골이_존재하지_않을시_예외를_발생한다() {
         // when & then
         assertThatThrownBy(() -> goalService.update(유효한_사용자_아이디, 존재하지_않는_골_아이디, 수정_요청한_골_dto))
                 .isInstanceOf(NotFoundGoalException.class);
     }
-    
+
     @Test
     void 골_수정을_요청한_사용자가_권한이_없을시_예외를_발생한다() {
         // when & then
         assertThatThrownBy(() -> goalService.update(골_관리자가_아닌_사용자_아이디, 유효한_골_아이디, 수정_요청한_골_dto))
                 .isInstanceOf(UpdateGoalForbiddenException.ForbiddenUserToUpdate.class);
     }
-    
+
     @Test
     void 수정_요청한_골_제목이_null인_경우_수정을_하지_않는다() {
         // when
         final ReadGoalDetailDto result = goalService.update(유효한_사용자_아이디, 유효한_골_아이디, 골_제목이_null인_수정_요청_골_dto);
-        
+
         // then
         assertSoftly(softAssertions -> {
             final List<ReadGoalDetailDto.GoalTeamDto> teams = result.teams();
@@ -195,7 +197,7 @@ class GoalServiceTest extends GoalServiceTestFixture {
             softAssertions.assertThat(teams.get(0).id()).isEqualTo(현재_로그인한_사용자.getId());
         });
     }
-    
+
     @Test
     void 수정_요청한_골_제목의_길이가_50자_초과이거나_빈값인_경우_예외를_발생한다() {
         // when & then
@@ -206,12 +208,12 @@ class GoalServiceTest extends GoalServiceTestFixture {
                           .isInstanceOf(InvalidGoalException.InvalidInvalidGoalName.class);
         });
     }
-    
+
     @Test
     void 수정_요청한_골_메모가_null인_경우_수정을_하지_않는다() {
         // when
         final ReadGoalDetailDto result = goalService.update(유효한_사용자_아이디, 유효한_골_아이디, 골_메모가_null인_수정_요청_골_dto);
-        
+
         // then
         assertSoftly(softAssertions -> {
             final List<ReadGoalDetailDto.GoalTeamDto> teams = result.teams();
@@ -222,12 +224,12 @@ class GoalServiceTest extends GoalServiceTestFixture {
             softAssertions.assertThat(teams.get(0).id()).isEqualTo(현재_로그인한_사용자.getId());
         });
     }
-    
+
     @Test
     void 수정_요청한_골_메모가_빈값인_경우_빈값을_저장한다() {
         // when
         final ReadGoalDetailDto result = goalService.update(유효한_사용자_아이디, 유효한_골_아이디, 골_메모가_빈값인_수정_요청_골_dto);
-        
+
         // then
         assertSoftly(softAssertions -> {
             final List<ReadGoalDetailDto.GoalTeamDto> teams = result.teams();
@@ -238,12 +240,12 @@ class GoalServiceTest extends GoalServiceTestFixture {
             softAssertions.assertThat(teams.get(0).id()).isEqualTo(현재_로그인한_사용자.getId());
         });
     }
-    
+
     @Test
     void 수정_요청한_골_종료날짜가_null인_경우_수정을_하지_않는다() {
         // when
         final ReadGoalDetailDto result = goalService.update(유효한_사용자_아이디, 유효한_골_아이디, 골_종료날짜가_null인_수정_요청_골_dto);
-        
+
         // then
         assertSoftly(softAssertions -> {
             final List<ReadGoalDetailDto.GoalTeamDto> teams = result.teams();
@@ -254,14 +256,14 @@ class GoalServiceTest extends GoalServiceTestFixture {
             softAssertions.assertThat(teams.get(0).name()).isEqualTo(현재_로그인한_사용자.getName());
         });
     }
-    
+
     @Test
     void 수정_요청한_골_종료날짜가_현재_저장된_종료날짜_보다_이전인_경우_예외를_발생한다() {
         // when & then
         assertThatThrownBy(() -> goalService.update(유효한_사용자_아이디, 유효한_골_아이디, 골_종료날짜가_현재_저장된_날짜보다_이전인_수정_요청_골_dto))
                 .isInstanceOf(InvalidGoalException.InvalidInvalidUpdateEndDate.class);
     }
-    
+
     @Test
     void 수정_요청한_참여자_목록이_null인_경우_수정을_하지_않는다() {
         // when
@@ -270,7 +272,7 @@ class GoalServiceTest extends GoalServiceTestFixture {
                 유효한_골_아이디,
                 골_참여자_목록이_null인_수정_요청_골_dto
         );
-        
+
         // then
         assertSoftly(softAssertions -> {
             final List<ReadGoalDetailDto.GoalTeamDto> teams = result.teams();
@@ -281,7 +283,7 @@ class GoalServiceTest extends GoalServiceTestFixture {
             softAssertions.assertThat(teams.get(0).id()).isEqualTo(현재_로그인한_사용자.getId());
         });
     }
-    
+
     @Test
     void 수정_요청한_참여자_목록이_빈값이거나_크기가_5보다_큰_경우_예외를_발생한다() {
         // when & then
@@ -290,6 +292,23 @@ class GoalServiceTest extends GoalServiceTestFixture {
                           .isInstanceOf(InvalidGoalException.InvalidInvalidUsersSize.class);
             softAssertions.assertThatThrownBy(() -> goalService.update(유효한_사용자_아이디, 유효한_골_아이디, 골_참여자_목록_크기가_5보다_큰_수정_요청_골_dto))
                           .isInstanceOf(InvalidGoalException.InvalidInvalidUsersSize.class);
+        });
+    }
+
+    @Test
+    @Transactional
+    void 골_초대를_수락한다() {
+        // when
+        goalService.acceptGoalRequest(골_관리자가_아닌_사용자_아이디, 현재_진행중인_골1.getId());
+        final List<GoalTeam> acceptedGoalTeam = 현재_진행중인_골1.getTeams()
+                                                          .stream()
+                                                          .filter(GoalTeam::isAccepted)
+                                                          .toList();
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(acceptedGoalTeam).hasSize(2);
+            softAssertions.assertThat(acceptedGoalTeam.get(0).getUser().getId()).isEqualTo(유효한_사용자_아이디);
+            softAssertions.assertThat(acceptedGoalTeam.get(1).getUser().getId()).isEqualTo(골_관리자가_아닌_사용자_아이디);
         });
     }
 }

--- a/src/test/java/com/backend/blooming/goal/domain/GoalTeamTest.java
+++ b/src/test/java/com/backend/blooming/goal/domain/GoalTeamTest.java
@@ -1,0 +1,33 @@
+package com.backend.blooming.goal.domain;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class GoalTeamTest extends GoalTeamTestFixture {
+
+    @Test
+    void 골_참여자가_골_초대를_수락하면_참을_반환한다() {
+        // given
+        final GoalTeam goalTeam = new GoalTeam(유효한_골_참여_사용자, 유효한_골);
+
+        // when
+        goalTeam.updateAccepted();
+
+        // then
+        assertThat(goalTeam.isAccepted()).isTrue();
+    }
+
+    @Test
+    void 골_관리자는_항상_골_수락을_참으로_한다() {
+        // when
+        final GoalTeam goalTeam = new GoalTeam(유효한_사용자, 유효한_골);
+
+        // then
+        assertThat(goalTeam.isAccepted()).isTrue();
+    }
+}

--- a/src/test/java/com/backend/blooming/goal/domain/GoalTeamTestFixture.java
+++ b/src/test/java/com/backend/blooming/goal/domain/GoalTeamTestFixture.java
@@ -1,0 +1,47 @@
+package com.backend.blooming.goal.domain;
+
+import com.backend.blooming.authentication.infrastructure.oauth.OAuthType;
+import com.backend.blooming.themecolor.domain.ThemeColor;
+import com.backend.blooming.user.domain.Email;
+import com.backend.blooming.user.domain.Name;
+import com.backend.blooming.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class GoalTeamTestFixture {
+
+    protected User 유효한_사용자 = User.builder()
+                                 .oAuthId("아이디")
+                                 .oAuthType(OAuthType.KAKAO)
+                                 .email(new Email("test@gmail.com"))
+                                 .name(new Name("테스트"))
+                                 .color(ThemeColor.BABY_BLUE)
+                                 .statusMessage("상태메시지")
+                                 .build();
+    protected User 유효한_골_참여_사용자 = User.builder()
+                                      .oAuthId("아이디2")
+                                      .oAuthType(OAuthType.KAKAO)
+                                      .email(new Email("test2@gmail.com"))
+                                      .name(new Name("테스트2"))
+                                      .color(ThemeColor.INDIGO)
+                                      .statusMessage("상태메시지2")
+                                      .build();
+    protected Goal 유효한_골;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(유효한_사용자, "id", 1L);
+        유효한_골 = Goal.builder()
+                    .name("골 제목")
+                    .memo("골 메모")
+                    .startDate(LocalDate.now())
+                    .endDate(LocalDate.now().plusDays(10))
+                    .managerId(유효한_사용자.getId())
+                    .users(List.of(유효한_사용자, 유효한_골_참여_사용자))
+                    .build();
+    }
+}

--- a/src/test/java/com/backend/blooming/goal/domain/TeamsTest.java
+++ b/src/test/java/com/backend/blooming/goal/domain/TeamsTest.java
@@ -88,4 +88,23 @@ class TeamsTest extends TeamsTestFixture {
         // then
         assertThat(actual).isFalse();
     }
+
+    @Test
+    void 골_팀_목록에_포함된_사용자의_골_초대를_수락한다() {
+        // given
+        final Teams teams = Teams.create(골_참여_사용자_목록, 유효한_골);
+
+        // when
+        teams.updateAccepted(골_참여자2.getId());
+        final List<GoalTeam> acceptedGoalTeam = teams.getGoalTeams()
+                                                     .stream()
+                                                     .filter(GoalTeam::isAccepted)
+                                                     .toList();
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(acceptedGoalTeam).hasSize(2);
+            softAssertions.assertThat(acceptedGoalTeam.get(0).getUser().getId()).isEqualTo(골_참여자.getId());
+            softAssertions.assertThat(acceptedGoalTeam.get(1).getUser().getId()).isEqualTo(골_참여자2.getId());
+        });
+    }
 }

--- a/src/test/java/com/backend/blooming/goal/domain/TeamsTestFixture.java
+++ b/src/test/java/com/backend/blooming/goal/domain/TeamsTestFixture.java
@@ -21,33 +21,36 @@ public class TeamsTestFixture {
     protected Goal 유효한_골;
 
     protected User 골_참여자 = User.builder()
-                             .oAuthId("아이디")
-                             .oAuthType(OAuthType.KAKAO)
-                             .email(new Email("test@gmail.com"))
-                             .name(new Name("테스트"))
-                             .color(ThemeColor.BABY_BLUE)
-                             .statusMessage("상태메시지")
-                             .build();
+                               .oAuthId("아이디")
+                               .oAuthType(OAuthType.KAKAO)
+                               .email(new Email("test@gmail.com"))
+                               .name(new Name("테스트"))
+                               .color(ThemeColor.BABY_BLUE)
+                               .statusMessage("상태메시지")
+                               .build();
     protected User 골_참여자2 = User.builder()
-                              .oAuthId("아이디2")
-                              .oAuthType(OAuthType.KAKAO)
-                              .email(new Email("test2@gmail.com"))
-                              .name(new Name("테스트2"))
-                              .color(ThemeColor.BABY_BLUE)
-                              .statusMessage("상태메시지2")
-                              .build();
+                                .oAuthId("아이디2")
+                                .oAuthType(OAuthType.KAKAO)
+                                .email(new Email("test2@gmail.com"))
+                                .name(new Name("테스트2"))
+                                .color(ThemeColor.BABY_BLUE)
+                                .statusMessage("상태메시지2")
+                                .build();
     protected User 추가된_골_참여자 = User.builder()
-                              .oAuthId("아이디3")
-                              .oAuthType(OAuthType.KAKAO)
-                              .email(new Email("test3@gmail.com"))
-                              .name(new Name("테스트3"))
-                              .color(ThemeColor.INDIGO)
-                              .statusMessage("상태메시지3")
-                              .build();
+                                   .oAuthId("아이디3")
+                                   .oAuthType(OAuthType.KAKAO)
+                                   .email(new Email("test3@gmail.com"))
+                                   .name(new Name("테스트3"))
+                                   .color(ThemeColor.INDIGO)
+                                   .statusMessage("상태메시지3")
+                                   .build();
     protected User 팀원이_아닌_사용자 = 추가된_골_참여자;
 
     @BeforeEach
     void setUp() {
+        ReflectionTestUtils.setField(골_참여자, "id", 1L);
+        ReflectionTestUtils.setField(골_참여자2, "id", 2L);
+        ReflectionTestUtils.setField(추가된_골_참여자, "id", 3L);
         골_참여_사용자_목록.addAll(List.of(골_참여자, 골_참여자2));
         크기가_5보다_큰_골_참여_사용자_목록.addAll(List.of(골_참여자, 골_참여자2, 골_참여자, 골_참여자2, 골_참여자, 골_참여자2));
         유효한_골 = Goal.builder()
@@ -55,12 +58,9 @@ public class TeamsTestFixture {
                     .memo("골 메모")
                     .startDate(LocalDate.now())
                     .endDate(LocalDate.now().plusDays(20))
-                    .managerId(1L)
+                    .managerId(골_참여자.getId())
                     .users(골_참여_사용자_목록)
                     .build();
         수정할_골_참여_사용자_목록.addAll(List.of(골_참여자, 골_참여자2, 추가된_골_참여자));
-        ReflectionTestUtils.setField(골_참여자, "id", 1L);
-        ReflectionTestUtils.setField(골_참여자2, "id", 2L);
-        ReflectionTestUtils.setField(추가된_골_참여자, "id", 3L);
     }
 }

--- a/src/test/java/com/backend/blooming/goal/presentation/GoalControllerTest.java
+++ b/src/test/java/com/backend/blooming/goal/presentation/GoalControllerTest.java
@@ -5,11 +5,11 @@ import com.backend.blooming.authentication.presentation.argumentresolver.Authent
 import com.backend.blooming.common.RestDocsConfiguration;
 import com.backend.blooming.goal.application.GoalService;
 import com.backend.blooming.goal.application.exception.DeleteGoalForbiddenException;
+import com.backend.blooming.goal.application.exception.InvalidGoalAcceptException;
 import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -53,32 +53,32 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class GoalControllerTest extends GoalControllerTestFixture {
-    
+
     @Autowired
     private MockMvc mockMvc;
-    
+
     @Autowired
     private ObjectMapper objectMapper;
-    
+
     @MockBean
     private GoalService goalService;
-    
+
     @Autowired
     private RestDocumentationResultHandler restDocs;
-    
+
     @MockBean
     private TokenProvider tokenProvider;
-    
+
     @MockBean
     private UserRepository userRepository;
-    
+
     @Test
     void 골_생성을_요청하면_새로운_골을_생성한다() throws Exception {
         // given
         given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.createGoal(유효한_골_생성_dto)).willReturn(유효한_골_아이디);
-        
+
         // when & then
         mockMvc.perform(post("/goals")
                 .header("X-API-VERSION", 1)
@@ -102,7 +102,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 )
         ));
     }
-    
+
     @Test
     void 골_생성시_관리자와_친구가_아닌_사용자가_참여자로_있는_경우_400_예외를_발생시킨다() throws Exception {
         // given
@@ -110,7 +110,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.createGoal(친구가_아닌_사용자가_참여자로_있는_골_생성_dto))
                 .willThrow(new InvalidGoalException.InvalidInvalidUserToParticipate());
-        
+
         // when & then
         mockMvc.perform(post("/goals")
                 .header("X-API-VERSION", 1)
@@ -122,7 +122,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 jsonPath("$.message").exists()
         ).andDo(print());
     }
-    
+
     @Test
     void 골_종료날짜가_시작날짜보다_이전인_경우_400_예외를_발생한다() throws Exception {
         // given
@@ -130,7 +130,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.createGoal(골_종료날짜가_시작날짜보다_이전인_골_생성_dto))
                 .willThrow(new InvalidGoalException.InvalidInvalidGoalPeriod());
-        
+
         // when & then
         mockMvc.perform(post("/goals")
                 .header("X-API-VERSION", 1)
@@ -142,7 +142,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 jsonPath("$.message").exists()
         ).andDo(print());
     }
-    
+
     @Test
     void 골_날짜가_100_초과인_경우_400_예외를_발생한다() throws Exception {
         // given
@@ -150,7 +150,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.createGoal(골_날짜수가_100_초과인_골_생성_dto))
                 .willThrow(new InvalidGoalException.InvalidInvalidGoalDays());
-        
+
         // when & then
         mockMvc.perform(post("/goals")
                 .header("X-API-VERSION", 1)
@@ -162,7 +162,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 jsonPath("$.message").exists()
         ).andDo(print());
     }
-    
+
     @Test
     void 골_생성시_사용자_리스트가_5명_초과인_경우_400_예외를_발생한다() throws Exception {
         // given
@@ -170,7 +170,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.createGoal(참여자_리스트가_5명_초과인_골_생성_dto))
                 .willThrow(new InvalidGoalException.InvalidInvalidUsersSize());
-        
+
         // when & then
         mockMvc.perform(post("/goals")
                 .header("X-API-VERSION", 1)
@@ -182,14 +182,14 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 jsonPath("$.message").exists()
         ).andDo(print());
     }
-    
+
     @Test
     void 골_아이디로_조회하면_해당_골의_정보를_반환한다() throws Exception {
         // given
         given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.readGoalDetailById(유효한_골_아이디)).willReturn(유효한_골_dto);
-        
+
         // when & then
         mockMvc.perform(get("/goals/{goalId}", 유효한_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -229,14 +229,14 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 )
         ));
     }
-    
+
     @Test
     void 존재하지_않는_골을_조회했을_때_404_예외를_발생한다() throws Exception {
         // given
         given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.readGoalDetailById(유효한_골_아이디)).willThrow(new NotFoundGoalException());
-        
+
         // when & then
         mockMvc.perform(get("/goals/{goalId}", 유효한_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -246,7 +246,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 jsonPath("$.message").exists()
         ).andDo(print());
     }
-    
+
     @Test
     void 현재_로그인한_사용자가_참여한_현재_진행중인_모든_골을_조회한다() throws Exception {
         // given
@@ -254,7 +254,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.readAllGoalByUserIdAndInProgress(사용자_토큰_정보.userId(), LocalDate.now()))
                 .willReturn(사용자가_참여한_현재_진행중인_골_목록_dto);
-        
+
         // when & then
         mockMvc.perform(get("/goals/all/progress")
                 .header("X-API-VERSION", 1)
@@ -280,7 +280,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 )
         ));
     }
-    
+
     @Test
     void 현재_로그인한_사용자가_참여한_종료된_모든_골을_조회한다() throws Exception {
         // given
@@ -288,7 +288,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.readAllGoalByUserIdAndFinished(사용자_토큰_정보.userId(), LocalDate.now()))
                 .willReturn(사용자가_참여한_종료된_골_목록_dto);
-        
+
         // when & then
         mockMvc.perform(get("/goals/all/finished")
                 .header("X-API-VERSION", 1)
@@ -314,14 +314,14 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 )
         ));
     }
-    
+
     @Test
     void 요청한_아이디의_골을_삭제한다() throws Exception {
         // given
         given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         willDoNothing().given(goalService).delete(유효한_골_아이디, 사용자_토큰_정보.userId());
-        
+
         // when & then
         mockMvc.perform(delete("/goals/{goalId}", 유효한_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -336,14 +336,14 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 )
         ));
     }
-    
+
     @Test
     void 삭제_요청한_아이디의_골이_존재하지_않는_경우_404_에러를_발생한다() throws Exception {
         // given
         given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         willThrow(new NotFoundGoalException()).given(goalService).delete(유효한_골_아이디, 사용자_토큰_정보.userId());
-        
+
         // when & then
         mockMvc.perform(delete("/goals/{goalId}", 유효한_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -353,14 +353,14 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 jsonPath("$.message").exists()
         ).andDo(print());
     }
-    
+
     @Test
     void 현재_로그인한_사용자가_요청한_아이디의_골을_삭제할_권한이_없는_경우_403_에러를_발생한다() throws Exception {
         // given
         given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         willThrow(new DeleteGoalForbiddenException()).given(goalService).delete(유효한_골_아이디, 사용자_토큰_정보.userId());
-        
+
         // when & then
         mockMvc.perform(delete("/goals/{goalId}", 유효한_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -370,14 +370,14 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 jsonPath("$.message").exists()
         ).andDo(print());
     }
-    
+
     @Test
     void 요청한_내용으로_골을_수정한다() throws Exception {
         // given
         given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.update(사용자_토큰_정보.userId(), 유효한_골_아이디, 수정_요청한_골_dto)).willReturn(수정_후_골_dto);
-        
+
         // when & then
         mockMvc.perform(patch("/goals/{goalId}", 유효한_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -420,7 +420,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 )
         ));
     }
-    
+
     @Test
     void 수정_요청한_골이_존재하지_않는_경우_404_에러를_발생한다() throws Exception {
         // given
@@ -428,7 +428,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.update(사용자_토큰_정보.userId(), 존재하지_않는_골_아이디, 수정_요청한_골_dto))
                 .willThrow(new NotFoundGoalException());
-        
+
         // when & then
         mockMvc.perform(patch("/goals/{goalId}", 존재하지_않는_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -440,7 +440,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 jsonPath("$.message").exists()
         ).andDo(print());
     }
-    
+
     @Test
     void 현재_로그인한_사용자가_요청한_아이디의_골을_수정할_권한이_없는_경우_403_에러를_발생한다() throws Exception {
         // given
@@ -448,7 +448,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.update(사용자_토큰_정보.userId(), 유효한_골_아이디, 수정_요청한_골_dto))
                 .willThrow(new UpdateGoalForbiddenException.ForbiddenUserToUpdate());
-        
+
         // when & then
         mockMvc.perform(patch("/goals/{goalId}", 유효한_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -460,7 +460,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 jsonPath("$.message").exists()
         ).andDo(print());
     }
-    
+
     @Test
     void 수정_요청한_골의_종료날짜가_기존_종료날짜보다_이전인_경우_400_에러를_발생한다() throws Exception {
         // given
@@ -468,7 +468,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.update(사용자_토큰_정보.userId(), 유효한_골_아이디, 수정_요청한_골_dto))
                 .willThrow(new InvalidGoalException.InvalidInvalidUpdateEndDate());
-        
+
         // when & then
         mockMvc.perform(patch("/goals/{goalId}", 유효한_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -480,7 +480,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 jsonPath("$.message").exists()
         ).andDo(print());
     }
-    
+
     @Test
     void 수정_요청한_골_종료날짜가_null인_경우_수정을_하지_않는다() throws Exception {
         // given
@@ -488,7 +488,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.update(사용자_토큰_정보.userId(), 유효한_골_아이디, 골_종료날짜가_null인_골_dto))
                 .willReturn(골_종료날짜가_null인_수정_후_골_dto);
-        
+
         // when & then
         mockMvc.perform(patch("/goals/{goalId}", 유효한_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -528,7 +528,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
                 )
         ));
     }
-    
+
     @Test
     void 수정_요청한_골_참여자_목록이_null인_경우_수정을_하지_않는다() throws Exception {
         // given
@@ -536,7 +536,7 @@ class GoalControllerTest extends GoalControllerTestFixture {
         given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
         given(goalService.update(사용자_토큰_정보.userId(), 유효한_골_아이디, 골_참여자_목록이_null인_골_dto))
                 .willReturn(골_참여자가_null인_수정_후_골_dto);
-        
+
         // when & then
         mockMvc.perform(patch("/goals/{goalId}", 유효한_골_아이디)
                 .header("X-API-VERSION", 1)
@@ -596,5 +596,43 @@ class GoalControllerTest extends GoalControllerTestFixture {
                         headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
                 )
         ));
+    }
+
+    @Test
+    void 골에_초대되지_않은_사람이_골_수락을_요청한_경우_400_에러를_발생한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
+        willThrow(new InvalidGoalAcceptException.InvalidInvalidUserToAcceptGoal())
+                .given(goalService)
+                .acceptGoalRequest(사용자_토큰_정보.userId(), 유효한_골_아이디);
+
+        // when & then
+        mockMvc.perform(post("/goals/{goalId}/accept", 유효한_골_아이디)
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+        ).andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.message").exists()
+        ).andDo(print());
+    }
+
+    @Test
+    void 골_관리자가_골_수락을_요청한_경우_400_에러를_발생한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
+        willThrow(new InvalidGoalAcceptException.InvalidInvalidGoalAcceptByManager())
+                .given(goalService)
+                .acceptGoalRequest(사용자_토큰_정보.userId(), 유효한_골_아이디);
+
+        // when & then
+        mockMvc.perform(post("/goals/{goalId}/accept", 유효한_골_아이디)
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+        ).andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.message").exists()
+        ).andDo(print());
     }
 }

--- a/src/test/java/com/backend/blooming/goal/presentation/GoalControllerTest.java
+++ b/src/test/java/com/backend/blooming/goal/presentation/GoalControllerTest.java
@@ -9,6 +9,7 @@ import com.backend.blooming.goal.application.exception.InvalidGoalException;
 import com.backend.blooming.goal.application.exception.NotFoundGoalException;
 import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenException;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -571,6 +572,28 @@ class GoalControllerTest extends GoalControllerTestFixture {
                         fieldWithPath("teams.[].name").type(JsonFieldType.STRING).description("골 참여자 이름"),
                         fieldWithPath("teams.[].colorCode").type(JsonFieldType.STRING).description("골 참여자 색상"),
                         fieldWithPath("teams.[].statusMessage").type(JsonFieldType.STRING).description("골 참여자 상태메시지")
+                )
+        ));
+    }
+
+    @Test
+    void 골_초대를_수락한다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
+        willDoNothing().given(goalService).acceptGoalRequest(사용자_토큰_정보.userId(), 유효한_골_아이디);
+
+        // when & then
+        mockMvc.perform(post("/goals/{goalId}/accept", 유효한_골_아이디)
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+        ).andExpectAll(
+                status().isNoContent()
+        ).andDo(print()).andDo(restDocs.document(
+                pathParameters(parameterWithName("goalId").description("조회할 골 아이디")),
+                requestHeaders(
+                        headerWithName("X-API-VERSION").description("요청 버전"),
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
                 )
         ));
     }


### PR DESCRIPTION
**3/10**
골 수락 기능 구현 완료했습니다. 이번주까지 시험이 있어서 진도를 많이 못나갔습니다.. 다음주부터 속도 내보겠습니다!
[주요 작업 내용]
- 골 초대 수락
    - 골 관리자의 경우 골 생성시에 자동으로 수락됨으로 처리
    - 골 참여자가 아니거나 골 참여자이지만 수락을 하지 않은 사용자는 단일 골 조회를 할 수 없도록 제한
- closed #58 

[질문]
1. 골 수락 기능 서비스 테스트를 하는데 로직에는 문제가 없는데 테스트에는 반영이 제대로 되지 않아서 혹시 트랜잭션 문제인가 싶어 `@Transactional` 을 테스트 메서드에 부여해주니 문제없이 잘 돌아가더라구요.. 이전까지 수정 기능 테스트하면서 트랜잭션 문제가 있었던 적이 없었는데 이번에 처음 발생한 문제라 정확한 원인을 좀 더 찾아보도록 하겠습니다. 우선 테스트 상으로는 문제가 없어 그대로 둘지 아니면 수정하는 것이 좋을지 질문드립니다!