### PR TITLE
스탬프 이미지 추가 기능 구현

### DIFF
--- a/src/main/java/com/backend/blooming/image/application/util/ImageStoragePath.java
+++ b/src/main/java/com/backend/blooming/image/application/util/ImageStoragePath.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ImageStoragePath {
 
-    PROFILE("profile/");
+    PROFILE("profile/"),
+    STAMP("stamp/");
 
     private final String path;
 }

--- a/src/main/java/com/backend/blooming/stamp/application/StampService.java
+++ b/src/main/java/com/backend/blooming/stamp/application/StampService.java
@@ -64,7 +64,7 @@ public class StampService {
         }
     }
 
-    private void validateExistStamp(final Long userId, final int day) {
+    private void validateExistStamp(final Long userId, final long day) {
         final boolean isExistsStamp = stampRepository.existsByUserIdAndDayAndDeletedIsFalse(userId, day);
         if (isExistsStamp) {
             throw new InvalidStampException.InvalidStampToCreate();

--- a/src/main/java/com/backend/blooming/stamp/application/StampService.java
+++ b/src/main/java/com/backend/blooming/stamp/application/StampService.java
@@ -42,7 +42,7 @@ public class StampService {
         final User user = getUser(createStampDto.userId());
         validateUserToCreateStamp(goal, user);
         validateExistStamp(user.getId(), createStampDto.day());
-        final String stampImageUrl = getStampImageUrl(createStampDto.stampImage());
+        final String stampImageUrl = saveStampImageUrl(createStampDto.stampImage());
         final Stamp stamp = persistStamp(createStampDto, goal, user, stampImageUrl);
 
         return ReadStampDto.from(stamp);
@@ -71,12 +71,9 @@ public class StampService {
         }
     }
 
-    private String getStampImageUrl(final MultipartFile stampImage) {
-        if (stampImage!=null && !stampImage.isEmpty()){
-            return imageStorageManager.upload(
-                    stampImage,
-                    ImageStoragePath.STAMP
-            );
+    private String saveStampImageUrl(final MultipartFile stampImage) {
+        if (stampImage != null && !stampImage.isEmpty()) {
+            return imageStorageManager.upload(stampImage, ImageStoragePath.STAMP);
         }
 
         return DEFAULT_STAMP_IMAGE_URL;

--- a/src/main/java/com/backend/blooming/stamp/application/StampService.java
+++ b/src/main/java/com/backend/blooming/stamp/application/StampService.java
@@ -21,6 +21,7 @@ import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -28,6 +29,8 @@ import java.util.List;
 @Transactional
 @RequiredArgsConstructor
 public class StampService {
+
+    private static final String DEFAULT_STAMP_IMAGE_URL = "";
 
     private final GoalRepository goalRepository;
     private final UserRepository userRepository;
@@ -39,10 +42,7 @@ public class StampService {
         final User user = getUser(createStampDto.userId());
         validateUserToCreateStamp(goal, user);
         validateExistStamp(user.getId(), createStampDto.day());
-        final String stampImageUrl = imageStorageManager.upload(
-                createStampDto.stampImage(),
-                ImageStoragePath.STAMP
-        );
+        final String stampImageUrl = getStampImageUrl(createStampDto.stampImage());
         final Stamp stamp = persistStamp(createStampDto, goal, user, stampImageUrl);
 
         return ReadStampDto.from(stamp);
@@ -69,6 +69,17 @@ public class StampService {
         if (isExistsStamp) {
             throw new InvalidStampException.InvalidStampToCreate();
         }
+    }
+
+    private String getStampImageUrl(final MultipartFile stampImage) {
+        if (stampImage!=null && !stampImage.isEmpty()){
+            return imageStorageManager.upload(
+                    stampImage,
+                    ImageStoragePath.STAMP
+            );
+        }
+
+        return DEFAULT_STAMP_IMAGE_URL;
     }
 
     private Stamp persistStamp(

--- a/src/main/java/com/backend/blooming/stamp/application/dto/CreateStampDto.java
+++ b/src/main/java/com/backend/blooming/stamp/application/dto/CreateStampDto.java
@@ -6,18 +6,23 @@ import org.springframework.web.multipart.MultipartFile;
 public record CreateStampDto(
         Long goalId,
         Long userId,
-        int day,
+        long day,
         String message,
         MultipartFile stampImage
 ) {
     
-    public static CreateStampDto of(final CreateStampRequest request, final Long goalId, final Long userId) {
+    public static CreateStampDto of(
+            final CreateStampRequest request,
+            final Long goalId,
+            final Long userId,
+            final MultipartFile stampImage
+    ) {
         return new CreateStampDto(
                 goalId,
                 userId,
                 request.day(),
                 request.message(),
-                request.stampImage()
+                stampImage
         );
     }
 }

--- a/src/main/java/com/backend/blooming/stamp/application/dto/CreateStampDto.java
+++ b/src/main/java/com/backend/blooming/stamp/application/dto/CreateStampDto.java
@@ -1,12 +1,14 @@
 package com.backend.blooming.stamp.application.dto;
 
 import com.backend.blooming.stamp.presentation.dto.request.CreateStampRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 public record CreateStampDto(
         Long goalId,
         Long userId,
         int day,
-        String message
+        String message,
+        MultipartFile stampImage
 ) {
     
     public static CreateStampDto of(final CreateStampRequest request, final Long goalId, final Long userId) {
@@ -14,7 +16,8 @@ public record CreateStampDto(
                 goalId,
                 userId,
                 request.day(),
-                request.message()
+                request.message(),
+                request.stampImage()
         );
     }
 }

--- a/src/main/java/com/backend/blooming/stamp/application/dto/ReadAllStampDto.java
+++ b/src/main/java/com/backend/blooming/stamp/application/dto/ReadAllStampDto.java
@@ -18,7 +18,8 @@ public record ReadAllStampDto(List<StampDto> stamps) {
             String name,
             ThemeColor color,
             String message,
-            long day
+            long day,
+            String stampImageUrl
     ) {
 
         public static StampDto from(final Stamp stamp) {
@@ -27,7 +28,8 @@ public record ReadAllStampDto(List<StampDto> stamps) {
                     stamp.getUser().getName(),
                     stamp.getUser().getColor(),
                     stamp.getMessage(),
-                    stamp.getDay()
+                    stamp.getDay(),
+                    stamp.getStampImageUrl()
             );
         }
     }

--- a/src/main/java/com/backend/blooming/stamp/application/dto/ReadStampDto.java
+++ b/src/main/java/com/backend/blooming/stamp/application/dto/ReadStampDto.java
@@ -8,7 +8,8 @@ public record ReadStampDto(
         String userName,
         ThemeColor userColor,
         long day,
-        String message
+        String message,
+        String stampImageUrl
 ) {
 
     public static ReadStampDto from(final Stamp stamp) {
@@ -17,7 +18,8 @@ public record ReadStampDto(
                 stamp.getUser().getName(),
                 stamp.getUser().getColor(),
                 stamp.getDay(),
-                stamp.getMessage()
+                stamp.getMessage(),
+                stamp.getStampImageUrl()
         );
     }
 }

--- a/src/main/java/com/backend/blooming/stamp/domain/Day.java
+++ b/src/main/java/com/backend/blooming/stamp/domain/Day.java
@@ -23,11 +23,11 @@ public class Day {
     @Column(name = "stamp_day", nullable = false)
     private long value;
 
-    public Day(final GoalTerm goalTerm, final int day) {
+    public Day(final GoalTerm goalTerm, final long day) {
         this.value = validateDay(goalTerm, day);
     }
 
-    private long validateDay(final GoalTerm goalTerm, final int day) {
+    private long validateDay(final GoalTerm goalTerm, final long day) {
         final long nowStampDay = DayUtil.getNowDay(goalTerm.getStartDate());
 
         if (day > nowStampDay) {

--- a/src/main/java/com/backend/blooming/stamp/domain/Stamp.java
+++ b/src/main/java/com/backend/blooming/stamp/domain/Stamp.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import software.amazon.awssdk.services.s3.endpoints.internal.Value;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,6 +27,8 @@ import lombok.ToString;
 @EqualsAndHashCode(of = "id", callSuper = false)
 @ToString(exclude = {"goal", "user"})
 public class Stamp extends BaseTimeEntity {
+
+    private static final String DEFAULT_STAMP_IMAGE_URL = "";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,6 +48,9 @@ public class Stamp extends BaseTimeEntity {
     @Embedded
     private Message message;
 
+    @Column(nullable = false)
+    private String stampImageUrl;
+
     @Column(name = "is_deleted", nullable = false)
     private boolean deleted = false;
 
@@ -53,12 +59,14 @@ public class Stamp extends BaseTimeEntity {
             final Goal goal,
             final User user,
             final Day day,
-            final Message message
+            final Message message,
+            final String stampImageUrl
     ) {
         this.goal = goal;
         this.user = user;
         this.day = day;
         this.message = message;
+        this.stampImageUrl = processDefaultStampImageUrl(stampImageUrl);
     }
 
     public long getDay() {
@@ -71,5 +79,13 @@ public class Stamp extends BaseTimeEntity {
 
     public boolean isWriter(final User user) {
         return this.user.equals(user);
+    }
+
+    private String processDefaultStampImageUrl(final String stampImageUrl) {
+        if (stampImageUrl == null || stampImageUrl.isBlank()) {
+            return DEFAULT_STAMP_IMAGE_URL;
+        }
+
+        return stampImageUrl;
     }
 }

--- a/src/main/java/com/backend/blooming/stamp/infrastructure/repository/StampRepository.java
+++ b/src/main/java/com/backend/blooming/stamp/infrastructure/repository/StampRepository.java
@@ -16,7 +16,7 @@ public interface StampRepository extends JpaRepository<Stamp, Long> {
                     WHERE (s.user.id = :userId AND s.day.value = :day) AND s.deleted = FALSE
                 ) as exist
             """)
-    boolean existsByUserIdAndDayAndDeletedIsFalse(final Long userId, final int day);
+    boolean existsByUserIdAndDayAndDeletedIsFalse(final Long userId, final long day);
 
     @Query("""
             SELECT s

--- a/src/main/java/com/backend/blooming/stamp/presentation/StampController.java
+++ b/src/main/java/com/backend/blooming/stamp/presentation/StampController.java
@@ -4,20 +4,21 @@ import com.backend.blooming.authentication.presentation.anotaion.Authenticated;
 import com.backend.blooming.authentication.presentation.argumentresolver.AuthenticatedUser;
 import com.backend.blooming.stamp.application.StampService;
 import com.backend.blooming.stamp.application.dto.CreateStampDto;
-import com.backend.blooming.stamp.application.dto.ReadStampDto;
 import com.backend.blooming.stamp.application.dto.ReadAllStampDto;
+import com.backend.blooming.stamp.application.dto.ReadStampDto;
 import com.backend.blooming.stamp.presentation.dto.request.CreateStampRequest;
-import com.backend.blooming.stamp.presentation.dto.response.ReadStampResponse;
 import com.backend.blooming.stamp.presentation.dto.response.ReadAllStampResponse;
+import com.backend.blooming.stamp.presentation.dto.response.ReadStampResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/goals")
@@ -29,10 +30,13 @@ public class StampController {
     @PostMapping(value = "/{goalId}/stamp", headers = "X-API-VERSION=1")
     public ResponseEntity<ReadStampResponse> createStamp(
             @PathVariable("goalId") final Long goalId,
-            @RequestBody @Valid final CreateStampRequest request,
+            @RequestPart @Valid final CreateStampRequest request,
+            @RequestPart(required = false) final MultipartFile stampImage,
             @Authenticated final AuthenticatedUser authenticatedUser
     ) {
-        final CreateStampDto createStampDto = CreateStampDto.of(request, goalId, authenticatedUser.userId());
+        final CreateStampDto createStampDto = CreateStampDto.of(
+                request, goalId, authenticatedUser.userId(), stampImage
+        );
         final ReadStampDto stamp = stampService.createStamp(createStampDto);
         final ReadStampResponse response = ReadStampResponse.from(stamp);
 

--- a/src/main/java/com/backend/blooming/stamp/presentation/StampController.java
+++ b/src/main/java/com/backend/blooming/stamp/presentation/StampController.java
@@ -35,7 +35,10 @@ public class StampController {
             @Authenticated final AuthenticatedUser authenticatedUser
     ) {
         final CreateStampDto createStampDto = CreateStampDto.of(
-                request, goalId, authenticatedUser.userId(), stampImage
+                request,
+                goalId,
+                authenticatedUser.userId(),
+                stampImage
         );
         final ReadStampDto stamp = stampService.createStamp(createStampDto);
         final ReadStampResponse response = ReadStampResponse.from(stamp);

--- a/src/main/java/com/backend/blooming/stamp/presentation/dto/request/CreateStampRequest.java
+++ b/src/main/java/com/backend/blooming/stamp/presentation/dto/request/CreateStampRequest.java
@@ -1,7 +1,11 @@
 package com.backend.blooming.stamp.presentation.dto.request;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record CreateStampRequest(
         int day,
-        String message
+        String message,
+
+        MultipartFile stampImage
 ) {
 }

--- a/src/main/java/com/backend/blooming/stamp/presentation/dto/request/CreateStampRequest.java
+++ b/src/main/java/com/backend/blooming/stamp/presentation/dto/request/CreateStampRequest.java
@@ -1,11 +1,7 @@
 package com.backend.blooming.stamp.presentation.dto.request;
 
-import org.springframework.web.multipart.MultipartFile;
-
 public record CreateStampRequest(
-        int day,
-        String message,
-
-        MultipartFile stampImage
+        long day,
+        String message
 ) {
 }

--- a/src/main/java/com/backend/blooming/stamp/presentation/dto/response/ReadAllStampResponse.java
+++ b/src/main/java/com/backend/blooming/stamp/presentation/dto/response/ReadAllStampResponse.java
@@ -23,7 +23,8 @@ public record ReadAllStampResponse(Map<Long, List<StampInfoResponse>> stamps) {
             String name,
             String color,
             String message,
-            long day
+            long day,
+            String stampImageUrl
     ) {
 
         public static StampInfoResponse from(final ReadAllStampDto.StampDto stampDto) {
@@ -32,7 +33,8 @@ public record ReadAllStampResponse(Map<Long, List<StampInfoResponse>> stamps) {
                     stampDto.name(),
                     stampDto.color().getCode(),
                     stampDto.message(),
-                    stampDto.day()
+                    stampDto.day(),
+                    stampDto.stampImageUrl()
             );
         }
     }

--- a/src/main/java/com/backend/blooming/stamp/presentation/dto/response/ReadStampResponse.java
+++ b/src/main/java/com/backend/blooming/stamp/presentation/dto/response/ReadStampResponse.java
@@ -7,7 +7,8 @@ public record ReadStampResponse(
         String userName,
         String userColor,
         long day,
-        String message
+        String message,
+        String stampImageUrl
 ) {
 
     public static ReadStampResponse from(final ReadStampDto stamp) {
@@ -16,7 +17,8 @@ public record ReadStampResponse(
                 stamp.userName(),
                 stamp.userColor().getCode(),
                 stamp.day(),
-                stamp.message()
+                stamp.message(),
+                stamp.stampImageUrl()
         );
     }
 }

--- a/src/main/resources/static/docs/docs.html
+++ b/src/main/resources/static/docs/docs.html
@@ -2335,8 +2335,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -2508,8 +2508,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -2537,8 +2537,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -2692,8 +2692,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-04-02",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-06",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -2717,8 +2717,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-04-02",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-06",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -2848,8 +2848,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-03-28",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-01",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -2873,8 +2873,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-03-28",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-01",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -3041,7 +3041,7 @@ Authorization: Bearer access_token
 {
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "endDate" : "2024-04-12",
+  "endDate" : "2024-04-16",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -3108,8 +3108,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-12",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-16",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -3143,8 +3143,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-12",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-16",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -3339,14 +3339,21 @@ Authorization: Bearer access_token</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /goals/1/stamp HTTP/1.1
-Content-Type: application/json;charset=UTF-8
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 X-API-VERSION: 1
 Authorization: Bearer access_token
 
-{
-  "day" : 1,
-  "message" : "스탬프 메시지"
-}</code></pre>
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=request
+Content-Type: application/json
+
+{"day":1,"message":"스탬프 메시지"}
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=stampImage; filename=image.png
+Content-Type: image/png
+
+image
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
 </div>
@@ -3419,7 +3426,8 @@ Content-Type: application/json
   "userName" : "스탬프 추가한 사용자",
   "userColor" : "#a1b3d7",
   "day" : 1,
-  "message" : "스탬프 메시지"
+  "message" : "스탬프 메시지",
+  "stampImageUrl" : "https://blooming.default.image.png"
 }</code></pre>
 </div>
 </div>
@@ -3464,6 +3472,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스탬프 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>stampImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">스탬프 이미지 url</p></td>
 </tr>
 </tbody>
 </table>
@@ -3526,20 +3539,23 @@ Content-Type: application/json
       "name" : "스탬프 추가한 사용자",
       "color" : "#a1b3d7",
       "message" : "스탬프 메시지1",
-      "day" : 1
+      "day" : 1,
+      "stampImageUrl" : "https://blooming.default.image.png"
     } ],
     "2" : [ {
       "userId" : 1,
       "name" : "스탬프 추가한 사용자",
       "color" : "#a1b3d7",
       "message" : "스탬프 메시지2",
-      "day" : 2
+      "day" : 2,
+      "stampImageUrl" : "https://blooming.default.image.png"
     }, {
       "userId" : 2,
       "name" : "스탬프 추가한 사용자2",
       "color" : "#7175a5",
       "message" : "스탬프 메시지3",
-      "day" : 2
+      "day" : 2,
+      "stampImageUrl" : "https://blooming.default.image.png"
     } ]
   }
 }</code></pre>
@@ -3586,6 +3602,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>stamps.*.[].day</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스탬프를 찍은 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>stamps.*.[].stampImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">스탬프 이미지 주소</p></td>
 </tr>
 </tbody>
 </table>
@@ -3996,7 +4017,7 @@ Authorization: Bearer access_token
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-22 20:05:41 +0900
+Last updated 2024-03-23 22:28:04 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/goal.html
+++ b/src/main/resources/static/docs/goal.html
@@ -456,8 +456,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -629,8 +629,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -658,8 +658,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -813,8 +813,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-04-02",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-06",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -838,8 +838,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-04-02",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-06",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -969,8 +969,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-03-28",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-01",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -994,8 +994,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-03-28",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-01",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -1162,7 +1162,7 @@ Authorization: Bearer access_token
 {
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "endDate" : "2024-04-12",
+  "endDate" : "2024-04-16",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -1229,8 +1229,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-12",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-16",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -1264,8 +1264,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-12",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-16",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {

--- a/src/main/resources/static/docs/stamp.html
+++ b/src/main/resources/static/docs/stamp.html
@@ -449,14 +449,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /goals/1/stamp HTTP/1.1
-Content-Type: application/json;charset=UTF-8
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 X-API-VERSION: 1
 Authorization: Bearer access_token
 
-{
-  "day" : 1,
-  "message" : "스탬프 메시지"
-}</code></pre>
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=request
+Content-Type: application/json
+
+{"day":1,"message":"스탬프 메시지"}
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=stampImage; filename=image.png
+Content-Type: image/png
+
+image
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
 </div>
@@ -529,7 +536,8 @@ Content-Type: application/json
   "userName" : "스탬프 추가한 사용자",
   "userColor" : "#a1b3d7",
   "day" : 1,
-  "message" : "스탬프 메시지"
+  "message" : "스탬프 메시지",
+  "stampImageUrl" : "https://blooming.default.image.png"
 }</code></pre>
 </div>
 </div>
@@ -574,6 +582,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스탬프 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>stampImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">스탬프 이미지 url</p></td>
 </tr>
 </tbody>
 </table>
@@ -636,20 +649,23 @@ Content-Type: application/json
       "name" : "스탬프 추가한 사용자",
       "color" : "#a1b3d7",
       "message" : "스탬프 메시지1",
-      "day" : 1
+      "day" : 1,
+      "stampImageUrl" : "https://blooming.default.image.png"
     } ],
     "2" : [ {
       "userId" : 1,
       "name" : "스탬프 추가한 사용자",
       "color" : "#a1b3d7",
       "message" : "스탬프 메시지2",
-      "day" : 2
+      "day" : 2,
+      "stampImageUrl" : "https://blooming.default.image.png"
     }, {
       "userId" : 2,
       "name" : "스탬프 추가한 사용자2",
       "color" : "#7175a5",
       "message" : "스탬프 메시지3",
-      "day" : 2
+      "day" : 2,
+      "stampImageUrl" : "https://blooming.default.image.png"
     } ]
   }
 }</code></pre>
@@ -697,6 +713,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스탬프를 찍은 날짜</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>stamps.*.[].stampImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">스탬프 이미지 주소</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -706,7 +727,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-22 20:05:41 +0900
+Last updated 2024-03-23 22:28:04 +0900
 </div>
 </div>
 </body>

--- a/src/test/java/com/backend/blooming/stamp/application/StampServiceTest.java
+++ b/src/test/java/com/backend/blooming/stamp/application/StampServiceTest.java
@@ -50,7 +50,8 @@ class StampServiceTest extends StampServiceTestFixture {
                 골.getId(),
                 스탬프를_생성할_사용자.getId(),
                 1,
-                "스탬프 메시지"
+                "스탬프 메시지",
+                추가할_스탬프_이미지
         );
 
         // when
@@ -111,6 +112,8 @@ class StampServiceTest extends StampServiceTestFixture {
             softAssertions.assertThat(stamps.get(1).userId()).isEqualTo(스탬프를_생성한_사용자_아이디2);
             softAssertions.assertThat(stamps.get(0).name()).isEqualTo(스탬프를_생성한_사용자_이름1);
             softAssertions.assertThat(stamps.get(1).name()).isEqualTo(스탬프를_생성한_사용자_이름2);
+            softAssertions.assertThat(stamps.get(0).stampImageUrl()).isEqualTo(스탬프_이미지_url);
+            softAssertions.assertThat(stamps.get(1).stampImageUrl()).isEqualTo(비어있는_스탬프_이미지);
         });
     }
 

--- a/src/test/java/com/backend/blooming/stamp/application/StampServiceTest.java
+++ b/src/test/java/com/backend/blooming/stamp/application/StampServiceTest.java
@@ -14,6 +14,8 @@ import com.backend.blooming.user.application.exception.NotFoundUserException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
@@ -64,6 +66,40 @@ class StampServiceTest extends StampServiceTestFixture {
             softAssertions.assertThat(result.userColor()).isEqualTo(스탬프를_생성할_사용자.getColor());
             softAssertions.assertThat(result.day()).isEqualTo(유효한_스탬프_dto.day());
             softAssertions.assertThat(result.message()).isEqualTo(유효한_스탬프_dto.message());
+        });
+    }
+
+    @Test
+    void 스탬프_이미지가_null이거나_빈값인_경우_빈_문자열을_주소로_저장한다() {
+        // given
+        final Goal 골 = Goal.builder()
+                           .name("골 제목")
+                           .memo("골 메모")
+                           .startDate(LocalDate.now())
+                           .endDate(LocalDate.now().plusDays(19))
+                           .managerId(스탬프를_생성할_사용자.getId())
+                           .users(List.of(스탬프를_생성할_사용자))
+                           .build();
+        goalRepository.save(골);
+
+        final CreateStampDto 스탬프_이미지가_null인_스탬프_dto = new CreateStampDto(
+                골.getId(),
+                스탬프를_생성할_사용자.getId(),
+                1,
+                "스탬프 메시지",
+                null
+        );
+
+        // when
+        final ReadStampDto result = stampService.createStamp(스탬프_이미지가_null인_스탬프_dto);
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(result.id()).isPositive();
+            softAssertions.assertThat(result.userName()).isEqualTo(스탬프를_생성할_사용자.getName());
+            softAssertions.assertThat(result.userColor()).isEqualTo(스탬프를_생성할_사용자.getColor());
+            softAssertions.assertThat(result.day()).isEqualTo(스탬프_이미지가_null인_스탬프_dto.day());
+            softAssertions.assertThat(result.message()).isEqualTo(스탬프_이미지가_null인_스탬프_dto.message());
         });
     }
 

--- a/src/test/java/com/backend/blooming/stamp/application/StampServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/stamp/application/StampServiceTestFixture.java
@@ -38,6 +38,7 @@ public class StampServiceTestFixture {
     protected CreateStampDto 골_참여자가_아닌_사용자가_생성한_스탬프_dto;
     protected CreateStampDto 골_초대를_수락하지_않은_사용자가_생성한_스탬프_dto;
     protected CreateStampDto 이미_존재하는_스탬프_dto;
+    protected CreateStampDto 스탬프_이미지가_null인_스탬프_dto;
     protected Long 유효한_골_아이디;
     protected Long 존재하지_않는_골_아이디 = 999L;
     protected Long 스탬프를_생성한_사용자_아이디1;
@@ -56,17 +57,18 @@ public class StampServiceTestFixture {
     );
     protected String 스탬프_이미지_url = "https://blooming.default.image.png";
     protected String 비어있는_스탬프_이미지 = "";
+    protected User 스탬프를_생성한_사용자1;
 
     @BeforeEach
     void setUp() {
-        User 스탬프를_생성한_사용자1 = User.builder()
-                                 .oAuthId("아이디")
-                                 .oAuthType(OAuthType.KAKAO)
-                                 .email(new Email("test@gmail.com"))
-                                 .name(new Name("테스트"))
-                                 .color(ThemeColor.BABY_BLUE)
-                                 .statusMessage("상태메시지")
-                                 .build();
+        스탬프를_생성한_사용자1 = User.builder()
+                            .oAuthId("아이디")
+                            .oAuthType(OAuthType.KAKAO)
+                            .email(new Email("test@gmail.com"))
+                            .name(new Name("테스트"))
+                            .color(ThemeColor.BABY_BLUE)
+                            .statusMessage("상태메시지")
+                            .build();
         User 스탬프를_생성한_사용자2 = User.builder()
                                  .oAuthId("아이디2")
                                  .oAuthType(OAuthType.KAKAO)

--- a/src/test/java/com/backend/blooming/stamp/application/StampServiceTestFixture.java
+++ b/src/test/java/com/backend/blooming/stamp/application/StampServiceTestFixture.java
@@ -15,6 +15,8 @@ import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import org.testcontainers.shaded.com.google.common.net.MediaType;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -46,6 +48,14 @@ public class StampServiceTestFixture {
     protected String 스탬프를_생성한_사용자_이름2;
     protected User 스탬프를_생성할_사용자;
     protected Goal 스탬프를_생성할_골;
+    protected MockMultipartFile 추가할_스탬프_이미지 = new MockMultipartFile(
+            "stampImage",
+            "image.png",
+            MediaType.PNG.toString(),
+            "image".getBytes()
+    );
+    protected String 스탬프_이미지_url = "https://blooming.default.image.png";
+    protected String 비어있는_스탬프_이미지 = "";
 
     @BeforeEach
     void setUp() {
@@ -113,12 +123,14 @@ public class StampServiceTestFixture {
                               .user(스탬프를_생성한_사용자1)
                               .day(new Day(스탬프를_생성할_골.getGoalTerm(), 1))
                               .message(new Message("스탬프 메시지"))
+                              .stampImageUrl(스탬프_이미지_url)
                               .build();
         Stamp 유효한_스탬프2 = Stamp.builder()
                               .goal(스탬프를_생성할_골)
                               .user(스탬프를_생성한_사용자2)
                               .day(new Day(스탬프를_생성할_골.getGoalTerm(), 1))
                               .message(new Message("스탬프 메시지2"))
+                              .stampImageUrl(비어있는_스탬프_이미지)
                               .build();
         stampRepository.saveAll(List.of(유효한_스탬프1, 유효한_스탬프2));
 
@@ -126,31 +138,36 @@ public class StampServiceTestFixture {
                 스탬프를_생성할_골.getId(),
                 999L,
                 1,
-                "스탬프 메시지"
+                "스탬프 메시지",
+                추가할_스탬프_이미지
         );
         존재하지_않는_골에서_생성된_스탬프_dto = new CreateStampDto(
                 999L,
                 스탬프를_생성한_사용자1.getId(),
                 1,
-                "스탬프 메시지"
+                "스탬프 메시지",
+                추가할_스탬프_이미지
         );
         골_참여자가_아닌_사용자가_생성한_스탬프_dto = new CreateStampDto(
                 스탬프를_생성할_골.getId(),
                 골_참여자가_아닌_사용자.getId(),
                 1,
-                "스탬프 메시지"
+                "스탬프 메시지",
+                추가할_스탬프_이미지
         );
         골_초대를_수락하지_않은_사용자가_생성한_스탬프_dto = new CreateStampDto(
                 스탬프를_생성할_골.getId(),
                 골_초대를_수락하지_않은_사용자.getId(),
                 1,
-                "스탬프 메시지"
+                "스탬프 메시지",
+                추가할_스탬프_이미지
         );
         이미_존재하는_스탬프_dto = new CreateStampDto(
                 스탬프를_생성할_골.getId(),
                 스탬프를_생성한_사용자1.getId(),
                 1,
-                "스탬프 메시지"
+                "스탬프 메시지",
+                추가할_스탬프_이미지
         );
     }
 }

--- a/src/test/java/com/backend/blooming/stamp/domain/StampTest.java
+++ b/src/test/java/com/backend/blooming/stamp/domain/StampTest.java
@@ -23,6 +23,7 @@ class StampTest extends StampTestFixture {
                                   .user(유효한_사용자)
                                   .day(new Day(유효한_골.getGoalTerm(), 1))
                                   .message(new Message("테스트 메시지"))
+                                  .stampImageUrl(스탬프_이미지_url)
                                   .build();
 
         // then
@@ -32,6 +33,28 @@ class StampTest extends StampTestFixture {
             softAssertions.assertThat(result.getUser().getName()).isEqualTo(유효한_사용자.getName());
             softAssertions.assertThat(result.getDay()).isEqualTo(1);
             softAssertions.assertThat(result.getMessage()).isEqualTo("테스트 메시지");
+            softAssertions.assertThat(result.getStampImageUrl()).isEqualTo(스탬프_이미지_url);
+        });
+    }
+
+    @Test
+    void 스탬프_생성시_이미지가_null이거나_빈값이면_빈_문자열로_주소를_저장한다() {
+        // when
+        final Stamp result = Stamp.builder()
+                                  .goal(유효한_골)
+                                  .user(유효한_사용자)
+                                  .day(new Day(유효한_골.getGoalTerm(), 1))
+                                  .message(new Message("테스트 메시지"))
+                                  .build();
+
+        // then
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(result).isNotNull();
+            softAssertions.assertThat(result.getGoal().getName()).isEqualTo(유효한_골.getName());
+            softAssertions.assertThat(result.getUser().getName()).isEqualTo(유효한_사용자.getName());
+            softAssertions.assertThat(result.getDay()).isEqualTo(1);
+            softAssertions.assertThat(result.getMessage()).isEqualTo("테스트 메시지");
+            softAssertions.assertThat(result.getStampImageUrl()).isEqualTo("");
         });
     }
 

--- a/src/test/java/com/backend/blooming/stamp/domain/StampTestFixture.java
+++ b/src/test/java/com/backend/blooming/stamp/domain/StampTestFixture.java
@@ -53,6 +53,7 @@ public class StampTestFixture {
                                                   .build();
     protected static int 스탬프_날짜가_골_시작일_이전인_경우 = 0;
     protected static int 스탬프_날짜가_현재_기준_스탬프_날짜보다_큰_경우 = 2;
+    protected String 스탬프_이미지_url = "https://blooming.default.image.png";
 
     @BeforeEach
     void setUpFixture() {

--- a/src/test/java/com/backend/blooming/stamp/presentation/StampControllerTest.java
+++ b/src/test/java/com/backend/blooming/stamp/presentation/StampControllerTest.java
@@ -9,7 +9,6 @@ import com.backend.blooming.stamp.application.exception.ForbiddenStampToCreateEx
 import com.backend.blooming.stamp.application.exception.ForbiddenStampToReadException;
 import com.backend.blooming.stamp.domain.exception.InvalidStampException;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -19,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -29,13 +29,13 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -49,9 +49,6 @@ class StampControllerTest extends StampControllerTestFixture {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockBean
     private StampService stampService;
@@ -73,34 +70,39 @@ class StampControllerTest extends StampControllerTestFixture {
         given(stampService.createStamp(유효한_스탬프_생성_dto)).willReturn(추가한_스탬프_dto);
 
         // when & then
-        mockMvc.perform(post("/goals/{goalId}/stamp", 유효한_골_아이디)
+        mockMvc.perform(multipart("/goals/{goalId}/stamp", 유효한_골_아이디, HttpMethod.POST)
+                .file(스탬프_추가_요청)
+                .file(추가할_스탬프_이미지)
+                .contentType(MediaType.MULTIPART_FORM_DATA)
                 .header("X-API-VERSION", 1)
                 .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(유효한_스탬프_생성_요청_dto))
         ).andExpectAll(
                 status().isOk(),
                 jsonPath("$.id", is(유효한_스탬프_응답_dto.id()), Long.class),
-                jsonPath("$.userName", is(유효한_스탬프_응답_dto.userName()), String.class),
-                jsonPath("$.userColor", is(유효한_스탬프_응답_dto.userColor()), String.class),
+                jsonPath("$.userName", is(유효한_스탬프_응답_dto.userName())),
+                jsonPath("$.userColor", is(유효한_스탬프_응답_dto.userColor())),
                 jsonPath("$.day", is(유효한_스탬프_응답_dto.day()), long.class),
-                jsonPath("$.message", is(유효한_스탬프_응답_dto.message()), String.class)
+                jsonPath("$.message", is(유효한_스탬프_응답_dto.message())),
+                jsonPath("$.stampImageUrl", is(유효한_스탬프_응답_dto.stampImageUrl()))
         ).andDo(print()).andDo(restDocs.document(
-                pathParameters(parameterWithName("goalId").description("스탬프를 생성할 골 아이디")),
+                pathParameters(
+                        parameterWithName("goalId").description("스탬프를 생성할 골 아이디")
+                ),
                 requestHeaders(
                         headerWithName("X-API-VERSION").description("요청 버전"),
                         headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
                 ),
-                requestFields(
-                        fieldWithPath("day").type(JsonFieldType.NUMBER).description("스탬프 날짜"),
-                        fieldWithPath("message").type(JsonFieldType.STRING).description("스탬프 메시지")
+                requestParts(
+                        partWithName("request").description("스탬프 정보"),
+                        partWithName("stampImage").description("스탬프 이미지")
                 ),
                 responseFields(
                         fieldWithPath("id").type(JsonFieldType.NUMBER).description("스탬프 아이디"),
                         fieldWithPath("userName").type(JsonFieldType.STRING).description("스탬프를 추가한 사용자 이름"),
                         fieldWithPath("userColor").type(JsonFieldType.STRING).description("스탬프를 추가한 사용자 테마 색상코드"),
                         fieldWithPath("day").type(JsonFieldType.NUMBER).description("스탬프 날짜"),
-                        fieldWithPath("message").type(JsonFieldType.STRING).description("스탬프 메시지")
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("스탬프 메시지"),
+                        fieldWithPath("stampImageUrl").type(JsonFieldType.STRING).description("스탬프 이미지 url")
                 )
         ));
     }
@@ -113,11 +115,12 @@ class StampControllerTest extends StampControllerTestFixture {
         given(stampService.createStamp(존재하지_않는_골에서_생성한_스탬프_dto)).willThrow(new NotFoundGoalException());
 
         // when & then
-        mockMvc.perform(post("/goals/{goalId}/stamp", 존재하지_않는_골_아이디)
+        mockMvc.perform(multipart("/goals/{goalId}/stamp", 존재하지_않는_골_아이디, HttpMethod.POST)
+                .file(존재하지_않는_골의_스탬프_추가_요청)
+                .file(추가할_스탬프_이미지)
                 .header("X-API-VERSION", 1)
                 .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(존재하지_않는_골에서_요청한_스탬프_생성_dto))
         ).andExpectAll(
                 status().isNotFound(),
                 jsonPath("$.message").exists()
@@ -132,11 +135,12 @@ class StampControllerTest extends StampControllerTestFixture {
         given(stampService.createStamp(권한이_없는_사용자가_생성한_스탬프_dto)).willThrow(new ForbiddenStampToCreateException());
 
         // when & then
-        mockMvc.perform(post("/goals/{goalId}/stamp", 유효한_골_아이디)
+        mockMvc.perform(multipart("/goals/{goalId}/stamp", 유효한_골_아이디, HttpMethod.POST)
+                .file(권한이_없는_사용자의_스탬프_추가_요청)
+                .file(추가할_스탬프_이미지)
                 .header("X-API-VERSION", 1)
                 .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(권한이_없는_사용자가_생성_요청한_스탬프_dto))
         ).andExpectAll(
                 status().isForbidden(),
                 jsonPath("$.message").exists()
@@ -152,11 +156,12 @@ class StampControllerTest extends StampControllerTestFixture {
                 .willThrow(new InvalidStampException.InvalidStampToCreate());
 
         // when & then
-        mockMvc.perform(post("/goals/{goalId}/stamp", 유효한_골_아이디)
+        mockMvc.perform(multipart("/goals/{goalId}/stamp", 유효한_골_아이디, HttpMethod.POST)
+                .file(이미_존재하는_스탬프_추가_요청)
+                .file(추가할_스탬프_이미지)
                 .header("X-API-VERSION", 1)
                 .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(이미_존재하는_스탬프_생성_요청_dto))
         ).andExpectAll(
                 status().isBadRequest(),
                 jsonPath("$.message").exists()
@@ -181,6 +186,7 @@ class StampControllerTest extends StampControllerTestFixture {
                 jsonPath("$.stamps.1.[0].color", is(유효한_스탬프_목록_응답.stamps().get(1L).get(0).color()), String.class),
                 jsonPath("$.stamps.1.[0].message", is(유효한_스탬프_목록_응답.stamps().get(1L).get(0).message()), String.class),
                 jsonPath("$.stamps.1.[0].day", is(유효한_스탬프_목록_응답.stamps().get(1L).get(0).day()), long.class),
+                jsonPath("$.stamps.1.[0].stampImageUrl", is(유효한_스탬프_목록_응답.stamps().get(1L).get(0).stampImageUrl()), String.class),
                 jsonPath("$.stamps.2.[0].userId", is(유효한_스탬프_목록_응답.stamps().get(2L).get(0).userId()), Long.class),
                 jsonPath("$.stamps.2.[1].userId", is(유효한_스탬프_목록_응답.stamps().get(2L).get(1).userId()), Long.class)
         ).andDo(print()).andDo(restDocs.document(
@@ -194,7 +200,8 @@ class StampControllerTest extends StampControllerTestFixture {
                         fieldWithPath("stamps.*.[].name").type(JsonFieldType.STRING).description("스탬프를 찍은 사용자 이름"),
                         fieldWithPath("stamps.*.[].color").type(JsonFieldType.STRING).description("스탬프를 찍은 사용자 프로필 색상코드"),
                         fieldWithPath("stamps.*.[].message").type(JsonFieldType.STRING).description("스탬프를 찍은 사용자 프로필 색상코드"),
-                        fieldWithPath("stamps.*.[].day").type(JsonFieldType.NUMBER).description("스탬프를 찍은 날짜")
+                        fieldWithPath("stamps.*.[].day").type(JsonFieldType.NUMBER).description("스탬프를 찍은 날짜"),
+                        fieldWithPath("stamps.*.[].stampImageUrl").type(JsonFieldType.STRING).description("스탬프 이미지 주소")
                 )
         ));
     }

--- a/src/test/java/com/backend/blooming/stamp/presentation/StampControllerTestFixture.java
+++ b/src/test/java/com/backend/blooming/stamp/presentation/StampControllerTestFixture.java
@@ -9,15 +9,23 @@ import com.backend.blooming.stamp.presentation.dto.request.CreateStampRequest;
 import com.backend.blooming.stamp.presentation.dto.response.ReadAllStampResponse;
 import com.backend.blooming.stamp.presentation.dto.response.ReadStampResponse;
 import com.backend.blooming.themecolor.domain.ThemeColor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.testcontainers.shaded.com.google.common.net.MediaType;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class StampControllerTestFixture {
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     private Long 골_관리자_아이디 = 1L;
     protected Long 골_참여자가_아닌_사용자_아이디 = 999L;
@@ -30,95 +38,94 @@ public class StampControllerTestFixture {
     protected MockMultipartFile 추가할_스탬프_이미지 = new MockMultipartFile(
             "stampImage",
             "image.png",
-            MediaType.PNG.toString(),
+            MediaType.IMAGE_PNG_VALUE,
             "image".getBytes()
     );
+    protected String 스탬프_이미지_url = "https://blooming.default.image.png";
 
     protected CreateStampDto 유효한_스탬프_생성_dto = new CreateStampDto(
             1L,
             골_관리자_아이디,
-            1,
+            1L,
             "스탬프 메시지",
             추가할_스탬프_이미지
     );
-    protected CreateStampRequest 유효한_스탬프_생성_요청_dto = new CreateStampRequest(
-            1,
-            "스탬프 메시지",
-            추가할_스탬프_이미지
+    private final CreateStampRequest 유효한_스탬프_생성_요청_dto = new CreateStampRequest(
+            1L,
+            "스탬프 메시지"
     );
     protected CreateStampDto 존재하지_않는_골에서_생성한_스탬프_dto = new CreateStampDto(
             999L,
             사용자_토큰_정보.userId(),
-            1,
+            1L,
             "스탬프 메시지",
             추가할_스탬프_이미지
     );
-    protected CreateStampRequest 존재하지_않는_골에서_요청한_스탬프_생성_dto = new CreateStampRequest(
-            1,
-            "스탬프 메시지",
-            추가할_스탬프_이미지
+    private final CreateStampRequest 존재하지_않는_골에서_요청한_스탬프_생성_dto = new CreateStampRequest(
+            1L,
+            "스탬프 메시지"
     );
     protected CreateStampDto 권한이_없는_사용자가_생성한_스탬프_dto = new CreateStampDto(
             1L,
             사용자_토큰_정보.userId(),
-            1,
+            1L,
             "스탬프 메시지",
             추가할_스탬프_이미지
     );
-    protected CreateStampRequest 권한이_없는_사용자가_생성_요청한_스탬프_dto = new CreateStampRequest(
-            1,
-            "스탬프 메시지",
-            추가할_스탬프_이미지
+    private CreateStampRequest 권한이_없는_사용자가_생성_요청한_스탬프_dto = new CreateStampRequest(
+            1L,
+            "스탬프 메시지"
     );
     protected CreateStampDto 이미_존재하는_스탬프_생성_dto = new CreateStampDto(
             1L,
             사용자_토큰_정보.userId(),
-            1,
+            1L,
             "스탬프 메시지",
             추가할_스탬프_이미지
     );
-    protected CreateStampRequest 이미_존재하는_스탬프_생성_요청_dto = new CreateStampRequest(
-            1,
-            "스탬프 메시지",
-            추가할_스탬프_이미지
+    private CreateStampRequest 이미_존재하는_스탬프_생성_요청_dto = new CreateStampRequest(
+            1L,
+            "스탬프 메시지"
     );
     protected ReadStampDto 추가한_스탬프_dto = new ReadStampDto(
             1L,
             "스탬프 추가한 사용자",
             ThemeColor.BABY_BLUE,
-            1,
-            "스탬프 메시지"
+            1L,
+            "스탬프 메시지",
+            스탬프_이미지_url
     );
     private ReadAllStampDto.StampDto 유효한_스탬프_dto = new ReadAllStampDto.StampDto(
             1L,
             "스탬프 추가한 사용자",
             ThemeColor.BABY_BLUE,
             "스탬프 메시지1",
-            1,
-            "https://blooming.default.image.png"
+            1L,
+            스탬프_이미지_url
     );
     private ReadAllStampDto.StampDto 유효한_스탬프_dto2 = new ReadAllStampDto.StampDto(
             1L,
             "스탬프 추가한 사용자",
             ThemeColor.BABY_BLUE,
             "스탬프 메시지2",
-            2,
-            "https://blooming.default.image.png"
+            2L,
+            스탬프_이미지_url
     );
     private ReadAllStampDto.StampDto 유효한_스탬프_dto3 = new ReadAllStampDto.StampDto(
             2L,
             "스탬프 추가한 사용자2",
             ThemeColor.INDIGO,
             "스탬프 메시지3",
-            2,
-            "https://blooming.default.image.png"
+            2L,
+            스탬프_이미지_url
     );
     protected ReadStampResponse 유효한_스탬프_응답_dto = new ReadStampResponse(
             1L,
             "스탬프 추가한 사용자",
             ThemeColor.BABY_BLUE.getCode(),
-            1,
-            "스탬프 메시지"
+            1L,
+            "스탬프 메시지",
+            스탬프_이미지_url
     );
     protected ReadAllStampDto 유효한_스탬프_목록_dto = new ReadAllStampDto(List.of(유효한_스탬프_dto, 유효한_스탬프_dto2, 유효한_스탬프_dto3));
     protected ReadAllStampResponse.StampInfoResponse 유효한_스탬프_응답_정보1 = new ReadAllStampResponse.StampInfoResponse(
@@ -126,21 +133,24 @@ public class StampControllerTestFixture {
             "스탬프 추가한 사용자",
             ThemeColor.BABY_BLUE.getCode(),
             "스탬프 메시지1",
-            1
+            1L,
+            스탬프_이미지_url
     );
     protected ReadAllStampResponse.StampInfoResponse 유효한_스탬프_응답_정보2 = new ReadAllStampResponse.StampInfoResponse(
             1L,
             "스탬프 추가한 사용자",
             ThemeColor.BABY_BLUE.getCode(),
             "스탬프 메시지2",
-            2
+            2L,
+            스탬프_이미지_url
     );
     protected ReadAllStampResponse.StampInfoResponse 유효한_스탬프_응답_정보3 = new ReadAllStampResponse.StampInfoResponse(
             2L,
             "스탬프 추가한 사용자2",
             ThemeColor.INDIGO.getCode(),
             "스탬프 메시지3",
-            2
+            2L,
+            스탬프_이미지_url
     );
     protected ReadAllStampResponse 유효한_스탬프_목록_응답 = new ReadAllStampResponse(
             new HashMap<>(
@@ -149,4 +159,36 @@ public class StampControllerTestFixture {
                     )
             )
     );
+    protected MockMultipartFile 스탬프_추가_요청;
+    protected MockMultipartFile 존재하지_않는_골의_스탬프_추가_요청;
+    protected MockMultipartFile 권한이_없는_사용자의_스탬프_추가_요청;
+    protected MockMultipartFile 이미_존재하는_스탬프_추가_요청;
+
+    @BeforeEach
+    void setUpFixture() throws JsonProcessingException {
+        스탬프_추가_요청 = new MockMultipartFile(
+                "request",
+                null,
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(유효한_스탬프_생성_요청_dto).getBytes(StandardCharsets.UTF_8)
+        );
+        존재하지_않는_골의_스탬프_추가_요청 = new MockMultipartFile(
+                "request",
+                null,
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(존재하지_않는_골에서_요청한_스탬프_생성_dto).getBytes(StandardCharsets.UTF_8)
+        );
+        권한이_없는_사용자의_스탬프_추가_요청 = new MockMultipartFile(
+                "request",
+                null,
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(권한이_없는_사용자가_생성_요청한_스탬프_dto).getBytes(StandardCharsets.UTF_8)
+        );
+        이미_존재하는_스탬프_추가_요청 = new MockMultipartFile(
+                "request",
+                null,
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(이미_존재하는_스탬프_생성_요청_dto).getBytes(StandardCharsets.UTF_8)
+        );
+    }
 }

--- a/src/test/java/com/backend/blooming/stamp/presentation/StampControllerTestFixture.java
+++ b/src/test/java/com/backend/blooming/stamp/presentation/StampControllerTestFixture.java
@@ -9,6 +9,8 @@ import com.backend.blooming.stamp.presentation.dto.request.CreateStampRequest;
 import com.backend.blooming.stamp.presentation.dto.response.ReadAllStampResponse;
 import com.backend.blooming.stamp.presentation.dto.response.ReadStampResponse;
 import com.backend.blooming.themecolor.domain.ThemeColor;
+import org.springframework.mock.web.MockMultipartFile;
+import org.testcontainers.shaded.com.google.common.net.MediaType;
 
 import java.util.HashMap;
 import java.util.List;
@@ -25,46 +27,60 @@ public class StampControllerTestFixture {
     protected String 액세스_토큰 = "Bearer access_token";
     protected Long 유효한_골_아이디 = 1L;
     protected Long 존재하지_않는_골_아이디 = 999L;
+    protected MockMultipartFile 추가할_스탬프_이미지 = new MockMultipartFile(
+            "stampImage",
+            "image.png",
+            MediaType.PNG.toString(),
+            "image".getBytes()
+    );
 
     protected CreateStampDto 유효한_스탬프_생성_dto = new CreateStampDto(
             1L,
             골_관리자_아이디,
             1,
-            "스탬프 메시지"
+            "스탬프 메시지",
+            추가할_스탬프_이미지
     );
     protected CreateStampRequest 유효한_스탬프_생성_요청_dto = new CreateStampRequest(
             1,
-            "스탬프 메시지"
+            "스탬프 메시지",
+            추가할_스탬프_이미지
     );
     protected CreateStampDto 존재하지_않는_골에서_생성한_스탬프_dto = new CreateStampDto(
             999L,
             사용자_토큰_정보.userId(),
             1,
-            "스탬프 메시지"
+            "스탬프 메시지",
+            추가할_스탬프_이미지
     );
     protected CreateStampRequest 존재하지_않는_골에서_요청한_스탬프_생성_dto = new CreateStampRequest(
             1,
-            "스탬프 메시지"
+            "스탬프 메시지",
+            추가할_스탬프_이미지
     );
     protected CreateStampDto 권한이_없는_사용자가_생성한_스탬프_dto = new CreateStampDto(
             1L,
             사용자_토큰_정보.userId(),
             1,
-            "스탬프 메시지"
+            "스탬프 메시지",
+            추가할_스탬프_이미지
     );
     protected CreateStampRequest 권한이_없는_사용자가_생성_요청한_스탬프_dto = new CreateStampRequest(
             1,
-            "스탬프 메시지"
+            "스탬프 메시지",
+            추가할_스탬프_이미지
     );
     protected CreateStampDto 이미_존재하는_스탬프_생성_dto = new CreateStampDto(
             1L,
             사용자_토큰_정보.userId(),
             1,
-            "스탬프 메시지"
+            "스탬프 메시지",
+            추가할_스탬프_이미지
     );
     protected CreateStampRequest 이미_존재하는_스탬프_생성_요청_dto = new CreateStampRequest(
             1,
-            "스탬프 메시지"
+            "스탬프 메시지",
+            추가할_스탬프_이미지
     );
     protected ReadStampDto 추가한_스탬프_dto = new ReadStampDto(
             1L,
@@ -78,21 +94,24 @@ public class StampControllerTestFixture {
             "스탬프 추가한 사용자",
             ThemeColor.BABY_BLUE,
             "스탬프 메시지1",
-            1
+            1,
+            "https://blooming.default.image.png"
     );
     private ReadAllStampDto.StampDto 유효한_스탬프_dto2 = new ReadAllStampDto.StampDto(
             1L,
             "스탬프 추가한 사용자",
             ThemeColor.BABY_BLUE,
             "스탬프 메시지2",
-            2
+            2,
+            "https://blooming.default.image.png"
     );
     private ReadAllStampDto.StampDto 유효한_스탬프_dto3 = new ReadAllStampDto.StampDto(
             2L,
             "스탬프 추가한 사용자2",
             ThemeColor.INDIGO,
             "스탬프 메시지3",
-            2
+            2,
+            "https://blooming.default.image.png"
     );
     protected ReadStampResponse 유효한_스탬프_응답_dto = new ReadStampResponse(
             1L,


### PR DESCRIPTION
**3/27**
스탬프 이미지 추가 기능 구현 완료했습니다.
s3 연동하는 부분 구현해주셔서 덕분에 쉽게 이미지 추가 및 조회 기능 구현 할 수 있었습니다. 감사합니다!
그리고 논의하고 싶은 부분이 있어 의견 남겨주시면 감사하겠습니다!

[논의사항]
스탬프 이미지 추가시에 지금은 /stamp 디렉터리를 그냥 바로 넣는 방식으로 구현했는데, 골 아이디 별로 디렉터리를 구분하는 게 나을까요? 
현재로서는 신고가 들어왔을 때 저희가 확인하기 용이하다는 것 외에는 현재 서비스에서 제공하는 기능에서 딱히 이점이 될만한 부분은 찾지 못해서 지금 당장은 /stamp 디렉터리에 바로 넣는 방식으로도 충분하다 생각했는데, 정수님 의견이 궁금합니다!
만약 골 아이디 별 혹은 날짜별로 디렉터리를 구분할 경우 스탬프 이미지 url은 enum으로 처리하기보다는 골 아이디 or 날짜를 추가한 스탬프 이미지 url 생성 메서드를 따로 추가해야할 것 같습니다. 

[작업 내용]
- 스탬프 추가 시 이미지까지 함께 저장하도록 추가
- 스탬프 추가 시 이미지가 null이거나 빈 값으로 들어온 경우 빈 문자열로 주소 저장
- 스탬프 이미지 주소 s3에 저장시 /stamp 디렉토리에 저장
- 스탬프 조회 시 이미지 주소 함께 조회하도록 추가
- closed #83 