### PR TITLE
골 생성시 참여자 목록이 null이거나 빈값인 경우 에러 발생하는 버그 해결 

### DIFF
--- a/src/main/java/com/backend/blooming/goal/application/GoalService.java
+++ b/src/main/java/com/backend/blooming/goal/application/GoalService.java
@@ -1,5 +1,6 @@
 package com.backend.blooming.goal.application;
 
+import com.backend.blooming.common.util.DayUtil;
 import com.backend.blooming.friend.infrastructure.repository.FriendRepository;
 import com.backend.blooming.goal.application.dto.CreateGoalDto;
 import com.backend.blooming.goal.application.dto.ReadAllGoalDto;
@@ -12,13 +13,12 @@ import com.backend.blooming.goal.application.exception.UpdateGoalForbiddenExcept
 import com.backend.blooming.goal.domain.Goal;
 import com.backend.blooming.goal.domain.GoalTeam;
 import com.backend.blooming.goal.infrastructure.repository.GoalRepository;
+import com.backend.blooming.notification.application.NotificationService;
 import com.backend.blooming.stamp.domain.Stamp;
 import com.backend.blooming.stamp.infrastructure.repository.StampRepository;
-import com.backend.blooming.notification.application.NotificationService;
 import com.backend.blooming.user.application.exception.NotFoundUserException;
 import com.backend.blooming.user.domain.User;
 import com.backend.blooming.user.infrastructure.repository.UserRepository;
-import com.backend.blooming.common.util.DayUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +47,9 @@ public class GoalService {
     }
 
     private List<User> getUsers(final List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            throw new InvalidGoalException.InvalidInvalidUsersSize();
+        }
         return userRepository.findAllByUserIds(userIds);
     }
 

--- a/src/main/java/com/backend/blooming/goal/domain/Goal.java
+++ b/src/main/java/com/backend/blooming/goal/domain/Goal.java
@@ -29,10 +29,7 @@ import java.util.List;
 public class Goal extends BaseTimeEntity {
 
     private static final String MEMO_DEFAULT = "";
-    private static final int TEAMS_MAXIMUM_LENGTH = 5;
     private static final int MAX_LENGTH_OF_NAME = 50;
-    private static final int START_INDEX_OF_NAME = 0;
-    private static final int END_INDEX_OF_NAME = 50;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/static/docs/docs.html
+++ b/src/main/resources/static/docs/docs.html
@@ -2335,8 +2335,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -2508,8 +2508,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -2537,8 +2537,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -2692,8 +2692,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-04-02",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-06",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -2717,8 +2717,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-04-02",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-06",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -2848,8 +2848,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-03-28",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-01",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -2873,8 +2873,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-03-28",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-01",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -3041,7 +3041,7 @@ Authorization: Bearer access_token
 {
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "endDate" : "2024-04-12",
+  "endDate" : "2024-04-16",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -3108,8 +3108,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-12",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-16",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -3143,8 +3143,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-12",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-16",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -3996,7 +3996,7 @@ Authorization: Bearer access_token
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-22 20:05:41 +0900
+Last updated 2024-03-23 22:28:04 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/goal.html
+++ b/src/main/resources/static/docs/goal.html
@@ -456,8 +456,8 @@ Authorization: Bearer access_token
 {
   "name" : "골 제목",
   "memo" : "골 메모",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -629,8 +629,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -658,8 +658,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "테스트 골1",
   "memo" : "테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-02",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-06",
   "days" : 11,
   "managerId" : 1,
   "teams" : [ {
@@ -813,8 +813,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-04-02",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-06",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -838,8 +838,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 1,
     "name" : "테스트 골1",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-04-02",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-06",
     "days" : 11,
     "teams" : [ {
       "id" : 1,
@@ -969,8 +969,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-03-28",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-01",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -994,8 +994,8 @@ Content-Type: application/json
   "goals" : [ {
     "id" : 2,
     "name" : "테스트 골2",
-    "startDate" : "2024-03-23",
-    "endDate" : "2024-03-28",
+    "startDate" : "2024-03-27",
+    "endDate" : "2024-04-01",
     "days" : 6,
     "teams" : [ {
       "id" : 1,
@@ -1162,7 +1162,7 @@ Authorization: Bearer access_token
 {
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "endDate" : "2024-04-12",
+  "endDate" : "2024-04-16",
   "teamUserIds" : [ 1, 2, 3 ]
 }</code></pre>
 </div>
@@ -1229,8 +1229,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-12",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-16",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {
@@ -1264,8 +1264,8 @@ Content-Type: application/json
   "id" : 1,
   "name" : "수정된 테스트 골1",
   "memo" : "수정된 테스트 골 메모1",
-  "startDate" : "2024-03-23",
-  "endDate" : "2024-04-12",
+  "startDate" : "2024-03-27",
+  "endDate" : "2024-04-16",
   "days" : 20,
   "managerId" : 1,
   "teams" : [ {

--- a/src/main/resources/static/docs/stamp.html
+++ b/src/main/resources/static/docs/stamp.html
@@ -706,7 +706,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-22 20:05:41 +0900
+Last updated 2024-03-23 22:28:04 +0900
 </div>
 </div>
 </body>

--- a/src/test/java/com/backend/blooming/goal/application/GoalServiceTest.java
+++ b/src/test/java/com/backend/blooming/goal/application/GoalServiceTest.java
@@ -1,6 +1,7 @@
 package com.backend.blooming.goal.application;
 
 import com.backend.blooming.configuration.IsolateDatabase;
+import com.backend.blooming.goal.application.dto.CreateGoalDto;
 import com.backend.blooming.goal.application.dto.ReadAllGoalDto;
 import com.backend.blooming.goal.application.dto.ReadGoalDetailDto;
 import com.backend.blooming.goal.application.exception.DeleteGoalForbiddenException;
@@ -16,6 +17,8 @@ import com.backend.blooming.user.application.exception.NotFoundUserException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
@@ -46,16 +49,34 @@ class GoalServiceTest extends GoalServiceTestFixture {
         assertThat(goalId).isPositive();
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    void 골_생성시_골_참여자_목록이_null이거나_비어있는_경우_예외를_발생한다(final List<Long> teamUserIds) {
+        // given
+        final CreateGoalDto 골_참여자_목록이_비어있는_골_생성_dto = new CreateGoalDto(
+                골_제목,
+                골_메모,
+                골_시작일,
+                골_종료일,
+                유효한_사용자_아이디,
+                teamUserIds
+        );
+
+        // when & then
+        assertThatThrownBy(() -> goalService.createGoal(골_참여자_목록이_비어있는_골_생성_dto))
+                .isInstanceOf(InvalidGoalException.InvalidInvalidUsersSize.class);
+    }
+
     @Test
     void 골_생성시_존재하지_않는_사용자가_관리자인_경우_예외를_발생한다() {
-        // when
+        // when & then
         assertThatThrownBy(() -> goalService.createGoal(존재하지_않는_사용자가_관리자인_골_생성_dto))
                 .isInstanceOf(NotFoundUserException.class);
     }
 
     @Test
     void 골_생성시_친구가_아닌_사용자가_참여자로_있는_경우_예외를_발생한다() {
-        // when
+        // when & then
         assertThatThrownBy(() -> goalService.createGoal(친구가_아닌_사용자가_참여자로_있는_골_생성_dto))
                 .isInstanceOf(InvalidGoalException.InvalidInvalidUserToParticipate.class);
     }

--- a/src/test/java/com/backend/blooming/goal/presentation/GoalControllerTest.java
+++ b/src/test/java/com/backend/blooming/goal/presentation/GoalControllerTest.java
@@ -105,6 +105,26 @@ class GoalControllerTest extends GoalControllerTestFixture {
     }
 
     @Test
+    void 골_생성시_골_참여자_목록이_null이거나_비어있는_경우_400_예외를_발생시킨다() throws Exception {
+        // given
+        given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);
+        given(userRepository.existsByIdAndDeletedIsFalse(사용자_토큰_정보.userId())).willReturn(true);
+        given(goalService.createGoal(유효한_골_생성_dto))
+                .willThrow(new InvalidGoalException.InvalidInvalidUsersSize());
+
+        // when & then
+        mockMvc.perform(post("/goals")
+                .header("X-API-VERSION", 1)
+                .header(HttpHeaders.AUTHORIZATION, 액세스_토큰)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(요청한_골_dto))
+        ).andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.message").exists()
+        ).andDo(print());
+    }
+
+    @Test
     void 골_생성시_관리자와_친구가_아닌_사용자가_참여자로_있는_경우_400_예외를_발생시킨다() throws Exception {
         // given
         given(tokenProvider.parseToken(액세스_토큰_타입, 액세스_토큰)).willReturn(사용자_토큰_정보);


### PR DESCRIPTION
골 생성시에 참여자 목록이 null값이거나 빈값인 경우 에러가 발생하는 버그가 있어 예외를 추가했습니다.
골 추가할 때 참여자 목록 범위를 확인하는 작업이 도메인 로직에 있어 서비스 로직에서는 따로 추가하지 않았는데, 입력받은 참여자 목록으로 실제 가입한 사용자들인지 조회하는 부분에서 예외처리를 하지 않아 에러가 발생한 것으로 보여 예외사항을 추가했습니다.
해당 부분은 빠르게 확인해보는 것이 좋을 것 같아 긴급배포하도록 하겠습니다.

- closed #91 